### PR TITLE
removes key management from lambda for KMS; uses a hardcoded master key

### DIFF
--- a/function.py
+++ b/function.py
@@ -28,8 +28,7 @@ def lambda_handler(event, context):
     uploader = src.Uploader(
         source_bucket,
         dest_bucket,
-        redshift=True,
-        encryption_key=os.environ.get('encryption_key')
+        redshift=True
     )
 
     uploader.run()

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -12,7 +12,7 @@ from .s3 import S3
 
 class Uploader:
 
-    def __init__(self, source_bucket, dest_bucket, s3=None, parsers=None, redshift=False, encryption_key="0fcc4091-b869-41a1-a909-f80534fedc62"):
+    def __init__(self, source_bucket, dest_bucket, s3=None, parsers=None, redshift=False, encryption_key="dc12706b-50ea-40b7-8d0e-206962aaa8f7"):
         logging.basicConfig(level=logging.INFO)
         self.redshift = redshift
         self.source_bucket = source_bucket


### PR DESCRIPTION
I've noticed that terraform does not seem to be a good way to manage KMS keys( hard to manage policies, lifecycle, etc) so I have moved to using a default master key. @mzia thinks this is a fine approach as well. 