### PR TITLE
Create Read-Only access group and Add dashboarduser

### DIFF
--- a/sql/dashboard_user.sql
+++ b/sql/dashboard_user.sql
@@ -1,0 +1,11 @@
+-- https://dba.stackexchange.com/a/156850
+
+CREATE GROUP view_only_group;
+
+CREATE USER dashboarduser WITH password $password;
+
+ALTER GROUP view_only_group ADD USER dashboarduser;
+
+GRANT USAGE ON SCHEMA "public" TO GROUP view_only_group;
+
+GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO GROUP view_only_group;


### PR DESCRIPTION
**Why**:
Currently, our `awsuser` has superuser privileges, which are beyond what is needed to view Tableau dashboards or perform other read-only activities.

**How**:
Create a View(Read) only group in our redshift cluster and add dashboard user to that group.

I've already created this group manually in `int` and tested with Tableau Desktop that I have all the access I need to create dashboards.