### PR TITLE
prevent pip from upgrading to pip 10

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ apt-get update
 apt-get install -y python-pip python3-pip python3-dev
 cd /usr/local/bin
 ln -s /usr/bin/python3 python
-pip3 install --upgrade pip
+pip install --upgrade pip==9.0.3
 cd $MAIN_DIR
 apt-get install -y zip
 apt-get install -y git
@@ -14,8 +14,8 @@ mkdir lambda_$1_deploy
 mkdir lambda_$1_deploy_hot
 cp -R src lambda_$1_deploy && cp function.py lambda_$1_deploy
 cp -R src lambda_$1_deploy_hot && cp function_2.py lambda_$1_deploy_hot
-pip3 install -Ur requirements.txt -t ./lambda_$1_deploy
-pip3 install -Ur requirements.txt -t ./lambda_$1_deploy_hot
+pip install -Ur requirements.txt -t ./lambda_$1_deploy
+pip install -Ur requirements.txt -t ./lambda_$1_deploy_hot
 cd lambda_$1_deploy
 find * -type d -name tests -exec rm -rf {} \;
 zip -r -q lambda_$1_deploy.zip .


### PR DESCRIPTION
Pip 10 is causing our lambda builds to break. Pin version to 9.0.3 as suggested in https://github.com/pypa/pip/issues/5240#issuecomment-381673100 