### PR TITLE
make sure that invalid chars and oversized strings are loaded

### DIFF
--- a/src/queries.py
+++ b/src/queries.py
@@ -147,19 +147,19 @@ class Queries:
                                 VALUES ('{}', '{}', '{}');"""
 
         # TODO: Switch to SQLAlchemy ORM in #3
-
+        # ACCEPTINVCHARS replaces invalid UTF-8 characters with '? by default
+        # Use ACCEPTINVCHARS as <your_replacement_char> if you want to override 
+        # the default '?'
         self.load_csv_redshift = """COPY {table_name} ({columns})
                             FROM :filepath
                             IAM_ROLE :iam_role
                             REGION :region
                             ACCEPTINVCHARS
-                            TRUNCATECOLUMNS
                             FORMAT AS CSV IGNOREHEADER 1;"""
-
+        
         self.load_csv = """COPY {table_name} ({columns})
                             FROM :filepath
                             ACCEPTINVCHARS
-                            TRUNCATECOLUMNS
                             CSV HEADER;"""
 
     def get_uploaded_files_lock(self):


### PR DESCRIPTION
Adding [data conversion parameters](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-conversion.html#copy-acceptinvchars) allow us to prevent invalid UTF-8 characters or strings that can't fit in a column to result into errors. 
