### PR TITLE
Scope uploaded_files check to last 5 days only for operational runs.

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -180,3 +180,4 @@ CREATE VIEW avg_daily_signups_by_month AS (
     ) e group by e.day ORDER BY e.day asc 
   ) ed group by ed.month ORDER BY ed.month asc
 );
+

--- a/src/database_connection.py
+++ b/src/database_connection.py
@@ -39,7 +39,7 @@ class DataBaseConnection:
             # If this is not a historical run, 
             # check the last 15 days uploaded files only.
             # Keeps this check from growing exponentially over time.
-            result = self.safe_query(self.q.get_uploaded_files_l10)
+            result = self.safe_query(self.q.get_uploaded_files_latest)
         else:
             result = self.safe_query(self.q.get_uploaded_files)
         return [(row['s3filename'], row['destination']) for row in result]

--- a/src/database_connection.py
+++ b/src/database_connection.py
@@ -39,7 +39,7 @@ class DataBaseConnection:
             # If this is not a historical run, 
             # check the last 15 days uploaded files only.
             # Keeps this check from growing exponentially over time.
-            result = self.safe_query(self.q.get_uploaded_files_l15)
+            result = self.safe_query(self.q.get_uploaded_files_l10)
         else:
             result = self.safe_query(self.q.get_uploaded_files)
         return [(row['s3filename'], row['destination']) for row in result]

--- a/src/database_connection.py
+++ b/src/database_connection.py
@@ -34,8 +34,14 @@ class DataBaseConnection:
             for query in self.q.get_build_queries(self.redshift)._asdict().values():
                 self.connection.execute(query)
 
-    def uploaded_files(self):
-        result = self.safe_query(self.q.get_uploaded_files)
+    def uploaded_files(self, check_historical_files = False):
+        if not check_historical_files:
+            # If this is not a historical run, 
+            # check the last 15 days uploaded files only.
+            # Keeps this check from growing exponentially over time.
+            result = self.safe_query(self.q.get_uploaded_files_l15)
+        else:
+            result = self.safe_query(self.q.get_uploaded_files)
         return [(row['s3filename'], row['destination']) for row in result]
 
     def mark_uploaded(self, filename, destination):

--- a/src/queries.py
+++ b/src/queries.py
@@ -154,6 +154,9 @@ class Queries:
         self.get_uploaded_files = """SELECT s3filename, destination
                                      FROM uploaded_files;"""
 
+        self.get_uploaded_files_l15 = """SELECT s3filename, destination
+                                     FROM uploaded_files where uploaded_at >= GETDATE() - interval '15 days';"""
+
         self.mark_uploaded = """INSERT INTO uploaded_files (s3filename, destination, uploaded_at)
                                 VALUES ('{}', '{}', '{}');"""
 

--- a/src/queries.py
+++ b/src/queries.py
@@ -154,8 +154,8 @@ class Queries:
         self.get_uploaded_files = """SELECT s3filename, destination
                                      FROM uploaded_files;"""
 
-        self.get_uploaded_files_l10 = """SELECT s3filename, destination
-                                     FROM uploaded_files where uploaded_at >= GETDATE() - interval '10 days';"""
+        self.get_uploaded_files_latest = """SELECT s3filename, destination
+                                     FROM uploaded_files where uploaded_at >= GETDATE() - interval '5 days';"""
 
         self.mark_uploaded = """INSERT INTO uploaded_files (s3filename, destination, uploaded_at)
                                 VALUES ('{}', '{}', '{}');"""

--- a/src/queries.py
+++ b/src/queries.py
@@ -154,8 +154,8 @@ class Queries:
         self.get_uploaded_files = """SELECT s3filename, destination
                                      FROM uploaded_files;"""
 
-        self.get_uploaded_files_l15 = """SELECT s3filename, destination
-                                     FROM uploaded_files where uploaded_at >= GETDATE() - interval '15 days';"""
+        self.get_uploaded_files_l10 = """SELECT s3filename, destination
+                                     FROM uploaded_files where uploaded_at >= GETDATE() - interval '10 days';"""
 
         self.mark_uploaded = """INSERT INTO uploaded_files (s3filename, destination, uploaded_at)
                                 VALUES ('{}', '{}', '{}');"""

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -14,7 +14,7 @@ from .s3 import S3
 
 class Uploader:
 
-    def __init__(self, source_bucket, dest_bucket, dest_bucket_parquet, hot_bucket, logger=None, s3=None, parsers=None, redshift=False, encryption_key="5d2d42ec-6b7f-4705-a1bb-7f4021a0df4d", lookback_period=None):
+    def __init__(self, source_bucket, dest_bucket, dest_bucket_parquet, hot_bucket, logger=None, s3=None, parsers=None, redshift=False, encryption_key="b10a84ce-1f80-44bc-8d0f-7a547b45ce53", lookback_period=None):
         self.redshift = redshift
         self.source_bucket = source_bucket
         self.dest_bucket = dest_bucket


### PR DESCRIPTION
Scopes that last uploaded_file check to look at past 5 days only.   
  
Problem: We are currently querying for the entire history of uploaded_files on every single run. This query is becoming too large to run operationally, and we need to look into other means of checking for already uploaded data. 
  
Fix: Query for the last 5 days of uploaded_files only.  
  
This isn't a clean fix. It will cause some issues if we ever run into a case where we have downtime > 5 days.  
  
