### PR TITLE
Moved docker teardown to a seperate make cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,4 @@ lambda_deploy: lambda_release
 	aws s3 cp lambda_$(TAG)_deploy.zip s3://tf-redshift-bucket-deployments/
 	aws s3 cp lambda_$(TAG)_deploy_hot.zip s3://tf-redshift-bucket-deployments-hot/
 	make lambda_cleanup
+	make docker_stop


### PR DESCRIPTION
Fixes the issue with build process failing because the docker container doesn't exist.  
  
