### PR TITLE
create view for account reset statistics

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -46,6 +46,11 @@ CREATE OR REPLACE VIEW personal_key_success_rate
       GROUP BY hour
     );
 
+CREATE OR REPLACE VIEW account_reset_and_cancel as (
+   SELECT user_ip, event_properties WHERE name = 'Account Reset'
+
+);
+
 CREATE VIEW experience_durations AS (
   WITH tj as (
     SELECT


### PR DESCRIPTION
Instead of a creating a separate table in redshift with an additional parser, it looks like a simple view(that can be iterated on) will suffice for the account reset data.

