### PR TITLE
alter uploaded files table schema

### DIFF
--- a/sql/table_migrations.sql
+++ b/sql/table_migrations.sql
@@ -170,3 +170,17 @@ BEGIN;
     DROP TABLE pageviews;
     ALTER TABLE pageviews_tt RENAME TO pageviews;
 END;
+
+BEGIN;
+ DROP TABLE IF EXISTS uploaded_files_tt;
+  CREATE TABLE uploaded_files_tt(
+     s3filename VARCHAR(500) NOT NULL,
+     destination VARCHAR(255) NOT NULL,
+      uploaded_at TIMESTAMP
+  )
+  SORTKEY(uploaded_at);
+  
+  INSERT INTO uploaded_files_tt(SELECT * FROM uploaded_files);
+  DROP TABLE uploaded_files;
+  ALTER TABLE uploaded_files_tt RENAME TO uploaded_files;
+END;


### PR DESCRIPTION
the majority of recent data redshift COPY outages(from lambda) were due to the fact that the `s3filename` column has a 100-char limit( and the files were of char length 101 ). as documented in #113 
recent errors:
```
sqlalchemy.exc.DataError: (psycopg2.DataError) value too long for type character varying(100)
[SQL: "INSERT INTO uploaded_files (s3filename, destination, uploaded_at)\n VALUES ('elk/2018-08-13/ls.s3.46fc2527-4598-458c-8166-acfee3370cf3.2018-08-13T23.58.tag_logstash.part10848.txt', 'pageviews', '2018-08-14 00:03:27.130423');"]
```
char length of filename:
```python
In [1]: len('elk/2018-08-13/ls.s3.46fc2527-4598-458c-8166-acfee3370cf3.2018-08-13T23.58.tag_logstash.part10848.txt')
Out[1]: 101
```
this PR:
* creates a new table with higher char limits to prevent this from happening again
* add a sortkey by timestamp to allow faster querying by redshift
