### PR TITLE
increase the char limit on Pageviews DDL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/
 .coverage
 .pytest_cache/*
 .vscode/*
+deactivate/*

--- a/deactivate/pip-selfcheck.json
+++ b/deactivate/pip-selfcheck.json
@@ -1,0 +1,1 @@
+{"last_check":"2018-08-16T16:10:19Z","pypi_version":"18.0"}

--- a/deactivate/pip-selfcheck.json
+++ b/deactivate/pip-selfcheck.json
@@ -1,1 +1,0 @@
-{"last_check":"2018-08-16T16:10:19Z","pypi_version":"18.0"}

--- a/sql/table_migrations.sql
+++ b/sql/table_migrations.sql
@@ -153,15 +153,15 @@ BEGIN;
     path VARCHAR(1024),
     format VARCHAR(255),
     controller VARCHAR(100),
-    action VARCHAR(15),
+    action VARCHAR(30),
     status SMALLINT,
     duration FLOAT,
-    user_id VARCHAR(40),
+    user_id VARCHAR(80),
     user_agent VARCHAR(4096),
-    ip VARCHAR(50),
+    ip VARCHAR(80),
     host VARCHAR(255),
     timestamp TIMESTAMP,
-    uuid VARCHAR(64) NOT NULL
+    uuid VARCHAR(80) NOT NULL
     )
     SORTKEY(timestamp);
 


### PR DESCRIPTION
Almost all the lambda ETL errors we are getting at the moment are caused by load errors on the `pageviews` table, since `piv_cac` integration was deploy in  production. Unfortunately, redshift does not specify exactly what column is exceeding string length. It just throws a generic `DDL length exceeded` error.

I am going to create an issue so that this can be further investigated, but in the meantime I'll change the table schema and increase the CHAR limit on the single-digit columns.


