### PR TITLE
Apply GitHub standard .gitignore for python project

### DIFF
--- a/sql/users/enduserteam.sql
+++ b/sql/users/enduserteam.sql
@@ -3,5 +3,7 @@ CREATE USER monfresh WITH password '$password'; # change $password to specific
 ALTER GROUP enduserteam ADD USER monfresh;
 GRANT USAGE ON SCHEMA "public" TO GROUP enduserteam;
 GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO GROUP enduserteam;
-CREATE USER ericmill WITH password '$my_password'; 
+CREATE USER ericmill WITH password '$my_password';
 ALTER GROUP enduserteam ADD USER ericmill;
+CREATE USER sanhehu WITH password '$my_password';
+ALTER GROUP enduserteam ADD USER sanhehu;


### PR DESCRIPTION
Since `identity-analytics-etl` is primarily a Python project, let's use the GitHub recommended `.gitignore`.