### PR TITLE
Improve the performance of duplication filter

### DIFF
--- a/function_2.py
+++ b/function_2.py
@@ -42,8 +42,8 @@ def lambda_handler(event, context):
 
     db = src.DataBaseConnection(redshift=True)
     db.build_db_if_needed()
-    uploaded_file_set = db.uploaded_files()
-    msg = "Got {} uploaded files in Redshift".format(len(uploaded_file_set))
+    uploaded_files = db.uploaded_files()
+    msg = "Got {} uploaded files in Redshift".format(len(uploaded_files))
     logging.info(msg)
 
     success_counter = 0
@@ -53,8 +53,7 @@ def lambda_handler(event, context):
         try:
             pth = "{}.txt".format('.'.join(f.split('.')[:-2]))
             table = f.split('.')[-2]
-            file_key = "{} - {}".format(pth, table)
-            if file_key in uploaded_file_set:
+            if (pth, table) in uploaded_files:
                 s3.delete_from_bucket(f)
                 continue
 

--- a/function_2.py
+++ b/function_2.py
@@ -16,6 +16,9 @@ def set_redshift_configs(env, acct_id):
     os.environ['env'] = env
 
 def lambda_handler(event, context):
+    logging.getLogger().setLevel(logging.INFO)
+    logging.info('function_2.py starting')
+
     os.environ['S3_USE_SIGV4'] = 'True'
     bucket = os.environ['hot_bucket']
     set_redshift_configs(os.environ['env'], os.environ['acct_id'])
@@ -36,26 +39,36 @@ def lambda_handler(event, context):
                }
     s3 = src.S3(bucket, bucket, bucket, bucket, bucket, os.environ['encryption_key'])
 
+    logging.info('s3.get_all_csv()')
     files = s3.get_all_csv()
-    msg = "Got {} csv files to copy to Redshift".format(len(files))
-    logging.info(msg)
+    logging.info("Found {} csv files to copy to Redshift".format(len(files)))
 
     db = src.DataBaseConnection(redshift=True)
     db.build_db_if_needed()
+
+    logging.info('Fetching list of all previously uploaded files')
     uploaded_files = db.uploaded_files()
-    msg = "Got {} uploaded files in Redshift".format(len(uploaded_files))
-    logging.info(msg)
+    logging.info('Found {} previously uploaded files in Redshift'.format(
+        len(uploaded_files)))
 
     success_counter = 0
     for f in files:
         if context.get_remaining_time_in_millis() < 10000:
+            logging.error('Ran out of time in lambda, exiting!')
             break
         try:
+            logging.info('Processing {!r}'.format(f))
+
             pth = "{}.txt".format('.'.join(f.split('.')[:-2]))
             table = f.split('.')[-2]
+
+            logging.info('Checking if previously uploaded')
             if (pth, table) in uploaded_files:
+                logging.info('File was previously uploaded, deleting it')
                 s3.delete_from_bucket(f)
                 continue
+
+            logging.info('Loading CSV into Redshift -- db.load_csv()')
 
             db.load_csv(table,
                         pth,
@@ -64,16 +77,20 @@ def lambda_handler(event, context):
                         os.environ['region'],
                         'arn:aws:iam::{}:role/tf-redshift-{}-iam-role'.format(
                         os.environ['acct_id'], os.environ['env']))
-            msg = "Successfully copy {} to redshift".format(f)
-            logging.info(msg)
+
+            logging.info('Finished copying to redshift, deleting from bucket')
             s3.delete_from_bucket(f)
 
             success_counter += 1
-            msg = "Successflly copied {} files to redshift".format(success_counter)
-            logging.info(msg)
+            logging.info('Done processing {!r}. Uploaded {} so far.'.format(
+                f, success_counter))
+
         # TO-DO: Add granular/specific exception handling
         except Exception as e:
             logging.exception("Error while processing CSV file {}".format(e))
             s3.delete_from_bucket(f)
 
     db.close_connection()
+
+    logging.info('Uploaded {} files this run out of {} pending'.format(
+        success_counter, len(files)))

--- a/src/database_connection.py
+++ b/src/database_connection.py
@@ -36,7 +36,7 @@ class DataBaseConnection:
 
     def uploaded_files(self):
         result = self.safe_query(self.q.get_uploaded_files)
-        return {"%s - %s" % (row['s3filename'], row['destination']) for row in result}
+        return {(row['s3filename'], row['destination']) for row in result}
 
     def mark_uploaded(self, filename, destination):
         uploaded_at = datetime.now()

--- a/src/database_connection.py
+++ b/src/database_connection.py
@@ -36,7 +36,7 @@ class DataBaseConnection:
 
     def uploaded_files(self):
         result = self.safe_query(self.q.get_uploaded_files)
-        return [(row['s3filename'], row['destination']) for row in result]
+        return {"%s - %s" % (row['s3filename'], row['destination']) for row in result}
 
     def mark_uploaded(self, filename, destination):
         uploaded_at = datetime.now()

--- a/src/s3.py
+++ b/src/s3.py
@@ -2,6 +2,7 @@ import boto3
 import io
 import gzip
 import pytz
+import logging
 
 from datetime import datetime, timedelta
 from botocore.config import Config
@@ -122,3 +123,5 @@ class S3:
 
     def delete_from_bucket(self, filename):
         self.hot_bucket.Object(filename).delete()
+        msg = "{} has been deleted".format(filename)
+        logging.info(msg)

--- a/tests/test_database_connection.py
+++ b/tests/test_database_connection.py
@@ -41,16 +41,16 @@ class DataBaseTestCases(unittest.TestCase):
     def test_uploaded_files(self):
         db_conn = self.setup()
         db_conn.mark_uploaded('a.txt', 'test')
-        self.assertTrue(('a.txt', 'test') in db_conn.uploaded_files())
+        self.assertTrue('a.txt - test' in db_conn.uploaded_files())
 
     def test_not_in_uploaded_files(self):
         db_conn = self.setup()
         db_conn.mark_uploaded('a.txt', 'test')
-        self.assertFalse(('b.txt', 'test') in db_conn.uploaded_files())
+        self.assertFalse('b.txt - test' in db_conn.uploaded_files())
 
     def test_csv_upload(self):
         db_conn = self.csv_upload()
-        self.assertTrue(('test_csv.dat', 'pageviews') in db_conn.uploaded_files())
+        self.assertTrue('test_csv.dat - pageviews' in db_conn.uploaded_files())
 
     def test_csv_upload_values(self):
         db_conn = self.csv_upload()

--- a/tests/test_database_connection.py
+++ b/tests/test_database_connection.py
@@ -41,16 +41,16 @@ class DataBaseTestCases(unittest.TestCase):
     def test_uploaded_files(self):
         db_conn = self.setup()
         db_conn.mark_uploaded('a.txt', 'test')
-        self.assertTrue('a.txt - test' in db_conn.uploaded_files())
+        self.assertTrue(('a.txt', 'test') in db_conn.uploaded_files())
 
     def test_not_in_uploaded_files(self):
         db_conn = self.setup()
         db_conn.mark_uploaded('a.txt', 'test')
-        self.assertFalse('b.txt - test' in db_conn.uploaded_files())
+        self.assertFalse(('b.txt', 'test') in db_conn.uploaded_files())
 
     def test_csv_upload(self):
         db_conn = self.csv_upload()
-        self.assertTrue('test_csv.dat - pageviews' in db_conn.uploaded_files())
+        self.assertTrue(('test_csv.dat', 'pageviews') in db_conn.uploaded_files())
 
     def test_csv_upload_values(self):
         db_conn = self.csv_upload()


### PR DESCRIPTION
**Why**:

1) We use ``uploaded_files`` table to store uploaded csv file name. And ``uploaded_files`` is used as a duplication filter. However, it uses list data structure to test if a new file already uploaded before. 

For example, if we have been uploaded X files, and we have Y files to copy to redshift, then we have to do X * Y comparison for each lambda invoke.

2) function2.py is the lambda handler that copy csv file to redshift. But it doesn't have sufficient log info for debugging.

**Solution**:

1) Use set data structure instead of list to filter file from ``uploaded_files``, it still needs to do a full table scan on ``uploaded_files`` for each invoke. This is a TEMP solution. Because the ideal solution takes lots of effort to implement.

2) more logging are added.