### PR TITLE
Fix typo browser_device_type

### DIFF
--- a/sql/create_table/events_devices.sql
+++ b/sql/create_table/events_devices.sql
@@ -8,7 +8,7 @@ create table if not exists public.events_devices (
     browser_platform_name varchar(255),
     browser_platform_version varchar(255),
     browser_device_name varchar(255),
-    browser_device_typed varchar(255),
+    browser_device_type varchar(255),
     browser_bot boolean,
     time timestamp
 );


### PR DESCRIPTION
Correct typo for browser_device_type column in events_devices table.