### PR TITLE
fix parser's format checker error

### DIFF
--- a/legacy_code/.gitignore
+++ b/legacy_code/.gitignore
@@ -18,3 +18,4 @@ test/
 .vscode/*
 deactivate/*
 .DS_Store
+tmp*

--- a/legacy_code/debug.py
+++ b/legacy_code/debug.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+"""
+This script help us to debug the parser.
+"""
+
+import os
+from src.event_parser import EventParser
+from src.pageview_parser import PageViewParser
+from src.device_parser import DeviceParser
+from src.email_parser import EmailParser
+from src.phone_parser import PhoneParser
+
+
+def debug():
+    """
+    Put your test log file at ./tmp.txt.
+    """
+    test_log_file_path = os.path.join(os.path.dirname(__file__), "tmp.txt")
+    parsers = (EventParser(), PageViewParser(), DeviceParser(), EmailParser(), PhoneParser())
+    for parser in parsers:
+        parsed_rows, total_rows, out, out_parquet = parser.stream_csv(open(test_log_file_path, "rb").read())
+        with open("{}.csv".format(parser.table), "w") as f:
+            f.write(out.read())
+        print(parser.table, parsed_rows)
+
+
+if __name__ == "__main__":
+    debug()

--- a/legacy_code/src/device_parser.py
+++ b/legacy_code/src/device_parser.py
@@ -3,9 +3,9 @@ import csv
 import re
 import io
 
-from .log_parser import Parser
+from .log_parser import BaseEventParser
 
-class DeviceParser(Parser):
+class DeviceParser(BaseEventParser):
     table = 'events_devices'
     uuids = set()
     header_fields = {
@@ -22,12 +22,14 @@ class DeviceParser(Parser):
         'time': str
     }
 
+    BROWSER_PATTERN = '"browser'
+
     def get_uuid(self, data):
         return data.get('id')
 
-    def format_check(self, line, line_num):
-        if ('event_properties' not in line) or ('browser' not in line) or (not self.has_valid_json(line, line_num)):
-            return True
+    def is_valid_format(self, line, line_num):
+        if self.BROWSER_PATTERN in line:
+            return super(DeviceParser, self).is_valid_format(line, line_num)
         else:
             return False
 

--- a/legacy_code/src/email_parser.py
+++ b/legacy_code/src/email_parser.py
@@ -3,9 +3,9 @@ import csv
 import re
 import io
 
-from .log_parser import Parser
+from .log_parser import BaseEventParser
 
-class EmailParser(Parser):
+class EmailParser(BaseEventParser):
     table = 'events_email'
     uuids = set()
     header_fields = {
@@ -15,12 +15,14 @@ class EmailParser(Parser):
         'time': str
     }
 
+    DOMAIN_PATTERN = '"domain_name"'
+
     def get_uuid(self, data):
         return data.get('id')
 
-    def format_check(self, line, line_num):
-        if ('event_properties' not in line) or ('domain_name' not in line) or (not self.has_valid_json(line, line_num)):
-            return True
+    def is_valid_format(self, line, line_num):
+        if  self.DOMAIN_PATTERN in line:
+            return super(EmailParser, self).is_valid_format(line, line_num)
         else:
             return False
 

--- a/legacy_code/src/event_parser.py
+++ b/legacy_code/src/event_parser.py
@@ -3,10 +3,10 @@ import csv
 import re
 import io
 
-from .log_parser import Parser
+from .log_parser import BaseEventParser
 
 
-class EventParser(Parser):
+class EventParser(BaseEventParser):
     table = 'events'
     header_fields = {
         'id': str,
@@ -33,12 +33,6 @@ class EventParser(Parser):
 
     uuids = set()
     service_provider_index = 6
-
-    def format_check(self, line, line_num):
-        if 'event_properties' not in line or not self.has_valid_json(line, line_num):
-            return True
-        else:
-            return False
 
     def get_uuid(self, data):
         return data.get('id')

--- a/legacy_code/src/log_parser.py
+++ b/legacy_code/src/log_parser.py
@@ -9,23 +9,23 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pandas as pd
 
+
 class Parser(object):
     header_fields = dict()
-    json_cache = dict() # key line number, value json data
+    json_cache = dict()  # key line number, value json data
 
     def stream_csv(self, in_io):
-        rows = 0
+        parsed_rows = 0
         out = io.StringIO()
         out_parquet = io.BytesIO()
         header_rows = self.header_fields.keys()
         df_data = list()
         writer = csv.writer(out, delimiter=',')
         writer.writerow(header_rows)
-
         lines = in_io.decode('utf-8').split('\n')
         logging.info("got {} lines to parse".format(len(lines)))
         for line_num, line in enumerate(lines):
-            if self.format_check(line, line_num):
+            if not self.is_valid_format(line, line_num):
                 continue
 
             result, uuid = self.json_to_csv(self.extract_json(line, line_num))
@@ -35,7 +35,7 @@ class Parser(object):
             self.uuids.add(uuid)
             writer.writerow(result)
             df_data.append(result)
-            rows += 1
+            parsed_rows += 1
         df = pd.DataFrame(df_data, columns=header_rows)
 
         # Pyarrow tries to infer types by default.
@@ -52,26 +52,34 @@ class Parser(object):
         out_parquet.seek(0)
         out.seek(0)
 
-        return rows, out, out_parquet
+        total_rows = len(lines)
+        return parsed_rows, total_rows, out, out_parquet
 
     def extract_json(self, line, line_num):
         if line_num in self.json_cache:
             return self.json_cache[line_num]
-        json_part = line[line.index('{'):]
-        return json.loads(json_part)
+        else:
+            try:
+                time_part, logger_part, json_part = line.split(" ", 2)
+            except ValueError:
+                raise ValueError
+
+            try:
+                data = json.loads(json_part)
+                self.json_cache[line_num] = data
+                return data
+            except ValueError:
+                raise ValueError
 
     def has_valid_json(self, line, line_num):
-        json_part = line[line.index('{'):]
-
         try:
-            self.json_cache[line_num] = json.loads(json_part)
-        except ValueError:
+            self.extract_json(line, line_num)
+            return True
+        except Exception as e:
             return False
 
-        return True
-
-    def format_check(self, line, line_num):
-        return self.has_valid_json(line, line_num)
+    def is_valid_format(self, line, line_num):
+        raise NotImplementedError
 
     def get_uuid(self, data):
         raise NotImplementedError()
@@ -90,3 +98,12 @@ class Parser(object):
         return df
 
 
+class BaseEventParser(Parser):
+    JSON_PREFIX_PATTERN = '{"name":'
+    ANALYTICS_EVENT_PATTERN = '"event_properties":'
+
+    def is_valid_format(self, line, line_num):
+        if (self.JSON_PREFIX_PATTERN in line) and (self.ANALYTICS_EVENT_PATTERN in line):
+            return self.has_valid_json(line, line_num)
+        else:
+            return False

--- a/legacy_code/src/log_parser.py
+++ b/legacy_code/src/log_parser.py
@@ -60,7 +60,7 @@ class Parser(object):
             return self.json_cache[line_num]
         else:
             try:
-                time_part, logger_part, json_part = line.split(" ", 2)
+                time_part, logger_part, json_part = line.strip().split(" ", 2)
             except ValueError:
                 raise ValueError
 

--- a/legacy_code/src/log_parser.py
+++ b/legacy_code/src/log_parser.py
@@ -99,7 +99,7 @@ class Parser(object):
 
 
 class BaseEventParser(Parser):
-    JSON_PREFIX_PATTERN = '{"name":'
+    JSON_PREFIX_PATTERN = '"name":'
     ANALYTICS_EVENT_PATTERN = '"event_properties":'
 
     def is_valid_format(self, line, line_num):

--- a/legacy_code/src/pageview_parser.py
+++ b/legacy_code/src/pageview_parser.py
@@ -10,26 +10,30 @@ from .log_parser import Parser
 class PageViewParser(Parser):
     table = 'pageviews'
     header_fields = {
-        'method': str, 
-        'path': str, 
-        'format': str, 
-        'controller': str, 
-        'action': str, 
-        'status': int, 
-        'duration': float, 
-        'user_id': str, 
-        'user_agent': str, 
+        'method': str,
+        'path': str,
+        'format': str,
+        'controller': str,
+        'action': str,
+        'status': int,
+        'duration': float,
+        'user_id': str,
+        'user_agent': str,
         'ip': str,
-        'host': str, 
-        'uuid': str, 
+        'host': str,
+        'uuid': str,
         'timestamp': str
     }
 
     uuids = set()
 
-    def format_check(self, line, line_num):
-        if ('{' not in line) or ('path' not in line or 'controller' not in line) or (not self.has_valid_json(line, line_num)):
-            return True
+    JSON_PREFIX_PATTERN = '{"method":'
+    PATH_PATTERN = '"path":'
+    CONTROLLER_PATTERN = '"controller":'
+
+    def is_valid_format(self, line, line_num):
+        if (self.JSON_PREFIX_PATTERN in line) and (self.PATH_PATTERN in line) and (self.CONTROLLER_PATTERN in line):
+            return self.has_valid_json(line, line_num)
         else:
             return False
 
@@ -41,14 +45,15 @@ class PageViewParser(Parser):
         if data.get('uuid'):
             return data.get('uuid')
         else:
-            return hashlib.sha256('|'.join([
-                                                data['path'],
-                                                data['ip'],
-                                                data['timestamp'],
-                                                data['host'],
-                                                str(data['duration'])
-                                           ]).encode('utf-8')
-                                 ).hexdigest()
+            return hashlib.sha256(
+                '|'.join([
+                    data['path'],
+                    data['ip'],
+                    data['timestamp'],
+                    data['host'],
+                    str(data['duration'])
+                ]).encode('utf-8')
+            ).hexdigest()
 
     def truncate_path(self, data):
         if data.get('path') is None:
@@ -68,19 +73,19 @@ class PageViewParser(Parser):
         """
         uuid = self.get_uuid(data)
         result = [
-                  data.get('method'),
-                  self.truncate_path(data),
-                  data.get('format'),
-                  data.get('controller'),
-                  data.get('action'),
-                  data.get('status'),
-                  data.get('duration'),
-                  data.get('user_id'),
-                  data.get('user_agent'),
-                  data.get('ip'),
-                  data.get('host'),
-                  uuid,
-                  re.sub(r" \+\d+$", '', data.get('timestamp'))
-                 ]
+            data.get('method'),
+            self.truncate_path(data),
+            data.get('format'),
+            data.get('controller'),
+            data.get('action'),
+            data.get('status'),
+            data.get('duration'),
+            data.get('user_id'),
+            data.get('user_agent'),
+            data.get('ip'),
+            data.get('host'),
+            uuid,
+            re.sub(r" \+\d+$", '', data.get('timestamp'))
+        ]
 
         return result, uuid

--- a/legacy_code/src/pageview_parser.py
+++ b/legacy_code/src/pageview_parser.py
@@ -27,7 +27,7 @@ class PageViewParser(Parser):
 
     uuids = set()
 
-    JSON_PREFIX_PATTERN = '{"method":'
+    JSON_PREFIX_PATTERN = '"method":'
     PATH_PATTERN = '"path":'
     CONTROLLER_PATTERN = '"controller":'
 

--- a/legacy_code/src/phone_parser.py
+++ b/legacy_code/src/phone_parser.py
@@ -3,9 +3,9 @@ import csv
 import re
 import io
 
-from .log_parser import Parser
+from .log_parser import BaseEventParser
 
-class PhoneParser(Parser):
+class PhoneParser(BaseEventParser):
     table = 'events_phone'
     uuids = set()
     header_fields = {
@@ -16,16 +16,19 @@ class PhoneParser(Parser):
         'country_code': str,
         'time': str
     }
-    
+
+    AREA_CODE_PATTERN = '"area_code"'
+    COUNTRY_CODE_PATTERN = '"country_code"'
+
     def get_uuid(self, data):
         return data.get('id')
     
-    def format_check(self, line, line_num):
-        if ('event_properties' not in line) or ('area_code' not in line) or ('country_code' not in line) or (not self.has_valid_json(line, line_num)):
-            return True
+    def is_valid_format(self, line, line_num):
+        if (self.AREA_CODE_PATTERN in line) and (self.COUNTRY_CODE_PATTERN in line):
+            return super(PhoneParser, self).is_valid_format(line, line_num)
         else:
             return False
-    
+
     def json_to_csv(self, data):
         uuid = self.get_uuid(data)
 

--- a/legacy_code/src/uploader.py
+++ b/legacy_code/src/uploader.py
@@ -59,16 +59,16 @@ class Uploader:
     def etl(self, parser, logfile, logfile_content):
         csv_name = "{}.{}.csv".format(logfile.replace('.txt', ''), parser.table)
         parquet_name = "{}/{}.snappy.parquet".format(parser.table, logfile.replace('.txt', ''))
-        processed_rows, out, out_parquet = parser.stream_csv(logfile_content)
+        parsed_rows, total_rows, out, out_parquet = parser.stream_csv(logfile_content)
 
-        self.logger.info("parsed {} rows".format(processed_rows))
-        if processed_rows > 0:
+        self.logger.info("parsed {} rows from {} rows".format(parsed_rows, total_rows))
+        if parsed_rows > 0:
             self.s3.new_file(out, csv_name)
             self.s3.new_file_parquet(out_parquet, parquet_name)
             self.s3.new_file_hot(out, csv_name)
 
         # Copy ~ X% files as-is to staging bucket.
-        if random.randint(1,100) <= self.staging_stream_rate:
+        if random.randint(1, 100) <= self.staging_stream_rate:
             self.s3.new_file_staging(self.s3.get_logfile(logfile), logfile)
 
         out.close()

--- a/legacy_code/tests/test_event_parser.py
+++ b/legacy_code/tests/test_event_parser.py
@@ -8,7 +8,7 @@ from io import BytesIO
 
 
 class EventParserTestCases(unittest.TestCase):
-    event_json = '{"id":"ff2d1183-3a82-42d6-8b08-19845ea8da3d","name":"Sign in page visited","properties":{"event_properties":{},"user_id":"anonymous-uuid","user_ip":"24.124.56.64","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36","host":"idp.staging.login.gov"},"visit_id":"e6808a77-4c6f-4feb-bca6-fc88e5f67292","visitor_id":"76e2e090-0f78-4b77-b5a6-bd5c6c2e484e","time":"2017-04-10T17:45:22.754Z"}'
+    event_json = '2017-04-10T17:45:24.621Z idp {"id":"ff2d1183-3a82-42d6-8b08-19845ea8da3d","name":"Sign in page visited","properties":{"event_properties":{},"user_id":"anonymous-uuid","user_ip":"24.124.56.64","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36","host":"idp.staging.login.gov"},"visit_id":"e6808a77-4c6f-4feb-bca6-fc88e5f67292","visitor_id":"76e2e090-0f78-4b77-b5a6-bd5c6c2e484e","time":"2017-04-10T17:45:22.754Z"}'
     test_event_log_txt = BytesIO(b"""
     2017-04-10T17:45:24.621Z idp 172.16.33.245 - - [10/Apr/2017:17:45:21 +0000] "GET / HTTP/1.1" 401 188 "-" "ELB-HealthChecker/2.0"
     2017-04-10T17:45:24.621Z idp 172.16.33.245 - - [10/Apr/2017:17:45:23 +0000] "GET /manifest.json HTTP/1.1" 304 0 "https://idp.staging.login.gov/?issuer=" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36"
@@ -17,7 +17,6 @@ class EventParserTestCases(unittest.TestCase):
     2017-04-10T17:45:29.022Z idp Apr 10 17:45:21 idp ossec: Alert Level: 5; Rule: 31101 - Web server 400 error code.; Location: idp->/opt/nginx/logs/access.log; srcip: 172.16.33.245; 172.16.33.245 - - [10/Apr/2017:17:45:21 +0000] "GET / HTTP/1.1" 401 188 "-" "ELB-HealthChecker/2.0"
     2017-04-10T17:45:43.383Z idp Apr 10 17:45:40 idp ossec: Alert Level: 5; Rule: 31101 - Web server 400 error code.; Location: idp->/opt/nginx/logs/access.log; srcip: 172.16.33.233; 172.16.33.233 - - [10/Apr/2017:17:45:39 +0000] "GET / HTTP/1.1" 401 188 "-" "ELB-HealthChecker/2.0"
     2017-04-10T17:45:44.023Z idp Apr 10 17:45:41 idp ossec: Alert Level: 5; Rule: 31101 - Web server 400 error code.; Location: idp->/opt/nginx/logs/access.log; srcip: 172.16.33.233; 172.16.33.233 - - [10/Apr/2017:17:45:39 +0000] "GET / HTTP/1.1" 401 188 "-" "ELB-HealthChecker/2.0"
-
     """)
     in_io = test_event_log_txt.read()
 
@@ -29,14 +28,13 @@ class EventParserTestCases(unittest.TestCase):
 
     def test_extract_json(self):
         parser = EventParser()
-        res = parser.extract_json(self.event_json, line_num=1)
-        self.assertEqual(res['id'], 'ff2d1183-3a82-42d6-8b08-19845ea8da3d')
-        self.assertEqual(res['properties']['user_ip'], '24.124.56.64')
-        self.assertEqual(res.keys(), json.loads(self.event_json).keys())
+        data = parser.extract_json(self.event_json, line_num=1)
+        self.assertEqual(data['id'], 'ff2d1183-3a82-42d6-8b08-19845ea8da3d')
+        self.assertEqual(data['properties']['user_ip'], '24.124.56.64')
 
     def test_json_to_csv(self):
         parser = EventParser()
-        data = json.loads(self.event_json)
+        data = parser.extract_json(self.event_json, line_num=1)
         res = parser.json_to_csv(data)[0]
         self.assertEqual(len(res), 20)
         self.assertEqual(res[8], '2017-04-10 17:45:22')

--- a/legacy_code/tests/test_event_parser.py
+++ b/legacy_code/tests/test_event_parser.py
@@ -23,8 +23,8 @@ class EventParserTestCases(unittest.TestCase):
 
     def test_stream_csv(self):
         parser = EventParser()
-        rows, out, out_parquet = parser.stream_csv(self.in_io)
-        self.assertEqual(rows, 1)
+        parsed_rows, total_rows, out, out_parquet = parser.stream_csv(self.in_io)
+        self.assertEqual(parsed_rows, 1)
         self.assertTrue(len(out_parquet.read()) > 0)
 
     def test_extract_json(self):

--- a/legacy_code/tests/test_pageview_parser.py
+++ b/legacy_code/tests/test_pageview_parser.py
@@ -25,8 +25,8 @@ class PageViewParserTestCases(unittest.TestCase):
 
     def test_stream_csv(self):
         parser = PageViewParser()
-        rows, out, out_parquet = parser.stream_csv(self.in_io)
-        self.assertEqual(rows, 2)
+        parsed_rows, total_rows, out, out_parquet = parser.stream_csv(self.in_io)
+        self.assertEqual(parsed_rows, 2)
         self.assertTrue(len(out_parquet.read()) > 0)
 
     def test_extract_json(self):

--- a/legacy_code/tests/test_phone_parser.py
+++ b/legacy_code/tests/test_phone_parser.py
@@ -8,7 +8,7 @@ from context import PhoneParser
 from io import BytesIO
 
 class PhoneParserTestCases(unittest.TestCase):
-    area_code_event_json = '{"id":"b17wpieoqf35-525a-44oeodb-c904d4ac0b1e","name":"OTP: Delivery Selection","properties":{"event_properties":{"success":true,"errors":{},"otp_delivery_preference":"sms","resend":null,"country_code":"1","area_code":"805","context":"confirmation"},"user_id":"06a2f306-0f89-4f53-ab20-ddf1a3e9edde","user_ip":"204.14.239.105","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36","host":"secure.login.gov","pid":18484},"visit_id":"7e05fd69-69bf-4d5e-882c-873488ac4f9a","visitor_id":"0a2d3b0a-c866-46ff-a6af-174455135a8a","time":"2017-10-22T19:44:13.775Z"}'
+    area_code_event_json = '2018-04-20T19:45:24.349Z idp {"id":"b17wpieoqf35-525a-44oeodb-c904d4ac0b1e","name":"OTP: Delivery Selection","properties":{"event_properties":{"success":true,"errors":{},"otp_delivery_preference":"sms","resend":null,"country_code":"1","area_code":"805","context":"confirmation"},"user_id":"06a2f306-0f89-4f53-ab20-ddf1a3e9edde","user_ip":"204.14.239.105","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36","host":"secure.login.gov","pid":18484},"visit_id":"7e05fd69-69bf-4d5e-882c-873488ac4f9a","visitor_id":"0a2d3b0a-c866-46ff-a6af-174455135a8a","time":"2017-10-22T19:44:13.775Z"}'
     
     test_event_log_txt = BytesIO(b"""
     2018-04-20T19:45:24.349Z idp-.login.gov [20/Apr/2018:19:45:15 +0000] secure.login.gov:443 : 00.000.000.47 - (172.16.33.247) - "HEAD /13746/ HTTP/1.1" 404 "Not Found" 0 Bytes "-" "DirBuster-0.12 (http://www.owasp.org/index.php/Category:OWASP_DirBuster_Project)" 0.035 sec "Root=b17wpieoqf35-525a-44oeodb-bdi512-c904d4ac0b1e"
@@ -19,17 +19,16 @@ class PhoneParserTestCases(unittest.TestCase):
 
     def test_extract_json(self):
       parser = PhoneParser()
-      res = parser.extract_json(self.area_code_event_json, line_num=1)
-      self.assertEqual(res['id'], 'b17wpieoqf35-525a-44oeodb-c904d4ac0b1e')
-      self.assertEqual(res['visit_id'], '7e05fd69-69bf-4d5e-882c-873488ac4f9a')
-      self.assertEqual(res['visitor_id'],'0a2d3b0a-c866-46ff-a6af-174455135a8a')
-      self.assertEqual(res['properties']['event_properties']['area_code'], '805')
-      self.assertEqual(res['properties']['event_properties']['country_code'], '1')
-      self.assertEqual(res.keys(), json.loads(self.area_code_event_json).keys())
+      data = parser.extract_json(self.area_code_event_json, line_num=1)
+      self.assertEqual(data['id'], 'b17wpieoqf35-525a-44oeodb-c904d4ac0b1e')
+      self.assertEqual(data['visit_id'], '7e05fd69-69bf-4d5e-882c-873488ac4f9a')
+      self.assertEqual(data['visitor_id'],'0a2d3b0a-c866-46ff-a6af-174455135a8a')
+      self.assertEqual(data['properties']['event_properties']['area_code'], '805')
+      self.assertEqual(data['properties']['event_properties']['country_code'], '1')
 
     def test_json_to_csv(self):
       parser = PhoneParser()
-      data = json.loads(self.area_code_event_json)
+      data = parser.extract_json(self.area_code_event_json, line_num=1)
       res = parser.json_to_csv(data)[0]
       self.assertEqual(len(res), 6)
       self.assertEqual(res[5], '2017-10-22 19:44:13')


### PR DESCRIPTION

**Why**:

We have not been receiving any data since 2018-10-19

**Reason**:

1. The ``elastic search`` got a problem,  so the logging system doesn't produce valid log. (Already Fixed)
2. After <1> fixed, we re-upload missing data, but **we still don't get any data in redshift**.
3. The format of the log line has been slightly changed. The parser can't locate the json data, and the new data doesn't pass the format check.

**Explain**:

- **Old format**: ``2017-04-10T17:45:24.621Z idp {"id":"dummy data","name":"Sign in page visited","properties":{"event_properties":{},``
- **New format**: ``2018-11-08T04:05:30.370Z {name=dummydata} {"name":"...":``

**Solution**:

Discussed with @brodygov @monfresh ,

1. use `" "` (space) as the separator to locate the json text.
2. use `"name": ...` and `"event_properties":...` to identify analytic events.
3. use `"method": ...`, `"path": ...` and `"controller": ...` to identify http events.

Example data:

```
2018-11-08T04:05:30.370Z {name=dummydata} {"name":"...":
2018-11-08T04:05:30.369Z {name=dummydata} {"method":"GET","path":"/?request_id=dummydata
```