### PR TITLE
Fix hot lambda to not reject cloudwatch log files.

### DIFF
--- a/legacy_code/secrets_manager.py
+++ b/legacy_code/secrets_manager.py
@@ -30,6 +30,7 @@ def get_redshift_secrets(env,region="us-west-2"):
             logging.exception("The Request was invalid due to {}".format(e))
         elif e.response["Error"]["Code"] == "InvalidParamentException":
             logging.exception("The request has invalid parameters {}".format(e))
+
         raise
     
     else:

--- a/legacy_code/src/s3.py
+++ b/legacy_code/src/s3.py
@@ -21,8 +21,8 @@ class S3:
         self.hot_bucket = self.conn.Bucket(hot_bucket)
         self.staging_bucket = self.conn.Bucket(staging_bucket)
         self.encryption_key = encryption_key
-        self.key_check = lambda key: ('.txt' in key) and ('cloud' not in key)
-        self.csv_check = lambda key: ('.csv' in key) and ('cloud' not in key)
+        self.key_check = lambda key: ('.txt' in key) and ('cloud' not in key or 'logstash' not in key)
+        self.csv_check = lambda key: ('.csv' in key) and ('cloud' not in key or 'logstash' not in key)
 
     def get_n_s3_logfiles(self, n):
         get_last_modified = lambda x: int(x.last_modified.strftime('%s'))


### PR DESCRIPTION
This selection code is intended to reject files that contain strings
like `cloudwatchlogstash` or `cloudtraillogstash`. It was very overly
broad to reject all filenames that contain `cloud`.

This was unexpectedly matching the directory
`imported_from_cloudwatch_logs/`.