### PR TITLE
disable secret manager

### DIFF
--- a/legacy_code/function.py
+++ b/legacy_code/function.py
@@ -4,24 +4,26 @@ import sys
 import boto3
 import logging
 import src
-import random
-
-from secrets_manager import get_redshift_secrets
 
 def set_redshift_configs():
     # The bucket name and filename
     # could all be defined inside of the lambda resource in terraform.
-    redshift_prod_password = get_redshift_secrets(os.environ['env'])["password"]
+    bucket = boto3.resource('s3').Bucket("login-gov-{}-{}-redshift-secrets".format(os.environ['env'], os.environ['acct_id']))
+    data = yaml.load(bucket.Object('redshift_secrets.yml').get()['Body'])
     os.environ['REDSHIFT_URI'] = "redshift+psycopg2://awsuser:{redshift_password}@{redshift_host}/analytics".format(
-        redshift_password=redshift_prod_password,
+        redshift_password=data['redshift_password'],
         redshift_host=os.environ['redshift_host']
     )
 
 def lambda_handler(event, context):
-    logging.basicConfig(level=logging.INFO)
+    logging.getLogger().setLevel(logging.INFO)
+    logging.info('Starting lambda_handler() in function.py')
     uploader_logger = logging.getLogger('uploader')
     set_redshift_configs()
     trigger_file = event['Records'][0]['s3']['object']['key']
+
+    logging.info('trigger_file: %r', trigger_file)
+
     dest_bucket = os.environ['dest_bucket']
     source_bucket = os.environ['source_bucket']
     staging_bucket = os.environ['staging_bucket']
@@ -30,7 +32,7 @@ def lambda_handler(event, context):
 
     # Percentage of data live data that should be copied to staging bucket.
     STAGING_STREAM_RATE = 10
-    
+
     uploader = src.Uploader(
         source_bucket,
         dest_bucket,
@@ -40,7 +42,10 @@ def lambda_handler(event, context):
         logger=uploader_logger,
         redshift=True,
         encryption_key=os.environ['encryption_key'],
-        staging_stream_rate=STAGING_STREAM_RATE
+        staging_stream_rate=STAGING_STREAM_RATE,
     )
 
+    logging.info('uploader: %r', uploader)
+
     uploader.run(trigger_file=trigger_file)
+    logging.info('Finished lambda_handler()')


### PR DESCRIPTION
*Description*:

the [secret_manager.py](https://github.com/18F/identity-analytics-
etl/blob/master/legacy_code/secrets_manager.py) are never been tested and set up.

`secret_manager.py` is trying to use [AWS Secret Manager](https://aws.amazon.com/secrets-manager/) to retrieve the credential in its runtime. But the corresponding setup is not done.
We should live with the old `reading credential from .yml` file solution until secret manager is properly set up and tested.

*Solution*:

Read credential from ``.yml`` file.


