### PR TITLE
Sanhe/add developer guide doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://img.shields.io/badge/Link-Document-blue.svg
+.. image:: https://img.shields.io/badge/Link-Document-brightgreen.svg
       :target: https://s3-us-west-2.amazonaws.com/login-gov-doc/login_analytics/index.html
 
 .. image:: https://img.shields.io/badge/Link-API-blue.svg
@@ -22,18 +22,3 @@ https://login.gov analytics code repo. Source code for:
 - Data ETL Pipeline
 - Analytics Query
 - Machine Learning Model
-
-Notes on 2018-11-07:
-
-    This project used to be the source code for `Redshift ETL pipeline <https://github.com/18F/identity-analytics-etl/tree/master/legacy_code>`_. We need a redesign to have a all-in-one solution for managing all kinds of analytics related work. The ETL pipeline will be an sub module of this project.
-
-
-Local development
-------------------------------------------------------------------------------
-Since AWS lambda only supports Python3.6 and Python2.7, so we use Python3.6 for development.
-
-If it is your new Mac laptop, run this to set up your development environment::
-
-    $ bash ./bin/setup-mac.sh
-
-- ROOT/.python-version: This file is used by pyenv to specify global version of Python to be used in all shells. Reference: https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-global .

--- a/bin/setup-mac.sh
+++ b/bin/setup-mac.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# This script installs:
+#
+# - HomeBrew: package manager for mac, https://brew.sh/
+# - pyenv: python version manager
+# - pyenv-virtualenv: python virtual environment manager
+# - Python3.6.2: our main analytics development version
 
 PY_VER="3.6.2"
 

--- a/docs/source/01-Document-Maintainer-Guide/01-Use-GitHub-Client-to-Update-Docs/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/01-Use-GitHub-Client-to-Update-Docs/index.rst
@@ -3,7 +3,7 @@
 Step by Step: Use GitHub Client to Update Docs
 ------------------------------------------------------------------------------
 
-This guide **is for people that doesn't familiar with Git**. If you already a git user, just create a branch from master.
+**This guide is for people that are not familiar with Git**. If you already a git user, just create a branch from master.
 
 1. Download Github Client here and install it: https://desktop.github.com/
 2. Login to your Github account from ``Menu`` -> ``Github Desktop`` -> ``Preference`` -> ``Sign In``
@@ -14,8 +14,8 @@ This guide **is for people that doesn't familiar with Git**. If you already a gi
 7. Click ``Current Branch`` on the main interface, switch to ``master`` branch. Make sure you are on ``master`` branch.
 8. Type in a new branch name and click ``Create New Branch``, the naming convention is ``<your-name>/<purpose-of-this-branch>``, switch to the branch you just created.
 9. Click ``Publish Branch``, this will publish your branch to cloud, which is identical to ``master`` at this moment, but cause you didn't change anything.
-10. Apply doc / file change, writing docs, do the actual works. **Usually it is just adding new** ``.rst`` / ``.md`` file to ``identity-analytics-etl/docs/source``.
-11. Select all changes you want to check in, add a summary, and click ``Commit to <your-branch-name>``. (**This will NOT apply any changes to the cloud repo, no worries**)
-12. Once everything's ready, click ``Publish origin``, so all your work is available on Github for code review.
-13. Start a ``Pull Request`` from <your-branch> to ``master`` on https://github.com/18F/identity-analytics-etl/pulls, write why you are doing this PR and how you solved it. And ask someone to reivew it.
-14. Once it is approved, click ``Squash and Merge``, merge changes to master.
+10. Make your desired document / file changes, write new documents etc. **Typically it involves adding new** ``.rst`` / ``.md`` file to ``identity-analytics-etl/docs/source``.
+11. Select all changes you want to check in, add a summary, and click ``Commit to <your-branch-name>``. (**This will NOT apply any changes to the cloud repo**)
+12. Once everything's ready, click ``Publish origin``, so that all of your changes are synced to Github for code review.
+13. Start a ``Pull Request`` from <your-branch> to ``master`` on https://github.com/18F/identity-analytics-etl/pulls, describe why you are creating this PR and what you did to address the need. And ask someone in the team to review it.
+14. Once it is approved, click ``Squash and Merge``. This will finally merge all of your changes to master branch.

--- a/docs/source/01-Document-Maintainer-Guide/01-Use-GitHub-Client-to-Update-Docs/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/01-Use-GitHub-Client-to-Update-Docs/index.rst
@@ -1,0 +1,21 @@
+.. _use-github-client-to-update-docs:
+
+Step by Step: Use GitHub Client to Update Docs
+------------------------------------------------------------------------------
+
+This guide **is for people that doesn't familiar with Git**. If you already a git user, just create a branch from master.
+
+1. Download Github Client here and install it: https://desktop.github.com/
+2. Login to your Github account from ``Menu`` -> ``Github Desktop`` -> ``Preference`` -> ``Sign In``
+3. Make sure the ``identity-analytics-etl`` repo owner added you to the member list, so you have the access.
+4. Clone the repository from ``Menu`` -> ``File`` -> ``Clone Repository``.
+5. Switch ``Current Directory`` to ``identity-analytics-etl`` from the main interface.
+6. Click ``Fetch Origin`` on the main interface to pull the latest code from Github. (You need to do this every time before creating a new branch in case the repo has been updated by someone else).
+7. Click ``Current Branch`` on the main interface, switch to ``master`` branch. Make sure you are on ``master`` branch.
+8. Type in a new branch name and click ``Create New Branch``, the naming convention is ``<your-name>/<purpose-of-this-branch>``, switch to the branch you just created.
+9. Click ``Publish Branch``, this will publish your branch to cloud, which is identical to ``master`` at this moment, but cause you didn't change anything.
+10. Apply doc / file change, writing docs, do the actual works. **Usually it is just adding new** ``.rst`` / ``.md`` file to ``identity-analytics-etl/docs/source``.
+11. Select all changes you want to check in, add a summary, and click ``Commit to <your-branch-name>``. (**This will NOT apply any changes to the cloud repo, no worries**)
+12. Once everything's ready, click ``Publish origin``, so all your work is available on Github for code review.
+13. Start a ``Pull Request`` from <your-branch> to ``master`` on https://github.com/18F/identity-analytics-etl/pulls, write why you are doing this PR and how you solved it. And ask someone to reivew it.
+14. Once it is approved, click ``Squash and Merge``, merge changes to master.

--- a/docs/source/01-Document-Maintainer-Guide/02-Doc-Maintenance-FAQ/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/02-Doc-Maintenance-FAQ/index.rst
@@ -1,0 +1,39 @@
+.. _doc-maintenance-faq:
+
+Doc Maintenance FAQ
+==============================================================================
+
+.. contents::
+    :local:
+
+
+Where is the link for the doc site?
+------------------------------------------------------------------------------
+
+The docs are deployed to https://s3-us-west-2.amazonaws.com/login-gov-doc/login_analytics/index.html. This website can be only accessed from GSA network. You need to connect to GSA VPN to visit the docs.
+
+
+Where is the source file for the doc?
+------------------------------------------------------------------------------
+
+- https://github.com/18F/identity-analytics-etl/tree/master/docs/source
+
+
+How can I view the changes after I updated the doc source?
+------------------------------------------------------------------------------
+
+.. code-block:: bash
+
+    # this will rebuild the doc site locally
+    $ make build_doc
+
+    # view changes
+    $ make view_doc
+
+
+How can I deploy the latest docs?
+------------------------------------------------------------------------------
+
+.. code-block:: bash
+
+    $ make deploy_doc

--- a/docs/source/01-Document-Maintainer-Guide/03-Sphinx-Doc-Quick-Explain/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/03-Sphinx-Doc-Quick-Explain/index.rst
@@ -1,0 +1,46 @@
+.. _sphinx-doc-quick-explain:
+
+Sphinx Doc Quick Explain
+==============================================================================
+
+**This documentation is for developer that does know much about** `sphinx doc <http://www.sphinx-doc.org/en/master/>`_, **but want know how to use it correctly to generate beautiful, self managed doc site**.
+
+**Important directory and file**:
+
+- repo root dir (alias ``repo-root``): ``identity-analytics-etl/``
+- doc source dir (alias ``doc-root``): ``identity-analytics-etl/docs/source/``.
+- image, icon, css, javascripts, and all static files: ``<doc-root>/_static``, this path should NOT be modified.
+- sphinx doc generator settings file: ``<doc-root>/conf.py``
+- the generator scripts: ``<repo-root>/docs/Makefile`` for MacOS and Linux, ``<repo-root>/docs/make.bat`` for Windows.
+
+
+Generate Documentation Static Site (Build Doc)
+------------------------------------------------------------------------------
+
+This command will generate the doc site in ``<repo-root>/docs/build/html/index.html``::
+
+    $ cd <repo-root>/docs
+    $ make html
+
+You should see something like::
+
+    Running Sphinx v1.8.1
+    updating environment:
+    reading sources...
+    preparing documents...
+    writing output...
+    generating indices...
+    build succeeded, xxx warnings.
+
+- **Success**: if you see the ``build succeeded``, you can ignore most of warnings. Usually, it means you defined a link label, but never used, which is totally fine. **Occasional typo or RST/MD syntax error will NOT STOP the build**.
+- **Failed**: if you didn't see the ``build succeeded``. Usually, it means your config file ``conf.py`` is not correctly setup, could be Python syntax error, could be variable definition error, import error.
+
+
+The ``conf.py`` file
+------------------------------------------------------------------------------
+
+It is the configuration file, and it is actually a Python scripts. You can define:
+
+1. Theme to use.
+2. Extension to use.
+3. Programmatically generate doc parts and do any black magic you want.

--- a/docs/source/01-Document-Maintainer-Guide/03-Sphinx-Doc-Quick-Explain/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/03-Sphinx-Doc-Quick-Explain/index.rst
@@ -3,7 +3,7 @@
 Sphinx Doc Quick Explain
 ==============================================================================
 
-**This documentation is for developer that does know much about** `sphinx doc <http://www.sphinx-doc.org/en/master/>`_, **but want know how to use it correctly to generate beautiful, self managed doc site**.
+**This documentation is for developers who are not familiar with** `sphinx doc <http://www.sphinx-doc.org/en/master/>`_, **but want to explore how to use it to generate a slick, well organized and self managed doc site**.
 
 **Important directory and file**:
 
@@ -33,13 +33,13 @@ You should see something like::
     build succeeded, xxx warnings.
 
 - **Success**: if you see the ``build succeeded``, you can ignore most of warnings. Usually, it means you defined a link label, but never used, which is totally fine. **Occasional typo or RST/MD syntax error will NOT STOP the build**.
-- **Failed**: if you didn't see the ``build succeeded``. Usually, it means your config file ``conf.py`` is not correctly setup, could be Python syntax error, could be variable definition error, import error.
+- **Failed**: if you did not  see the ``build succeeded`` message, it usually means that your config file ``conf.py`` is not correctly setup, which could be caused by a Python syntax error, a variable definition error, import error etc.
 
 
 The ``conf.py`` file
 ------------------------------------------------------------------------------
 
-It is the configuration file, and it is actually a Python scripts. You can define:
+This is the configuration file, and it is actually a Python script. You can define:
 
 1. Theme to use.
 2. Extension to use.

--- a/docs/source/01-Document-Maintainer-Guide/05-Markdown-vs-RST/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/05-Markdown-vs-RST/index.rst
@@ -1,0 +1,29 @@
+.. _md-vs-rst:
+
+Markdown vs RST
+==============================================================================
+In this project, doc writer can write docs in **either Markdown or RestructuredText** (RST).
+
+I believe most of people are familiar with Markdown, maybe not for RST.
+
+reStructuredText is a file format for textual data used primarily in the Python programming language community for technical documentation. Both Markdown and RST are lightweight markup language. **The RST syntax is very similar to Markdown**, You can think RST as a super set of Markdown, RST has everything in Markdown, but Markdown doesn't.
+
+.. list-table:: **Why RST**
+    :widths: 10 10
+    :header-rows: 1
+
+    * - Feature that RST has but Markdown NOT
+      - Why this feature useful
+    * - Include other doc content
+      - Help us break large doc into smaller piece, better maintainability.
+    * - Cross reference anywhere in the entire project.
+      - url link may change. Use a unique identifier label to link is more stable.
+    * - Programmatically generate doc content from data.
+      - Maintaining the data at two place in the code and in the doc is not good.
+
+**It is OK to write your doc in Markdown, but some design pattern will not be available**
+
+For more information about writing docs in RST:
+
+- RST Cheatsheet: https://github.com/ralsina/rst-cheatsheet/blob/master/rst-cheatsheet.rst
+- RST Quick Ref: http://docutils.sourceforge.net/docs/user/rst/quickref.html

--- a/docs/source/01-Document-Maintainer-Guide/05-Markdown-vs-RST/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/05-Markdown-vs-RST/index.rst
@@ -2,18 +2,16 @@
 
 Markdown vs RST
 ==============================================================================
-In this project, doc writer can write docs in **either Markdown or RestructuredText** (RST).
+**Markdown and reStructuredText (RST)** are two lightweight markup languages with plain text formatting syntax designed for easy input with any text editor, typically used for technical documentation as they emphasize plain-text readability. Both are widely used for API documentation, RST in Sphinx, the standard Python documentation system, and Markdown in Doxygen (optionally), MkDocs, the Rust Standard Library documentation, and other. Most developers are familiar with Markdown, however.
 
-I believe most of people are familiar with Markdown, maybe not for RST.
+reStructuredText is a file format for textual data used primarily in the Python programming language community for technical documentation. Both Markdown and RST are lightweight markup language. **The RST syntax is very similar to Markdown**, You can think of RST as a super set of Markdown, RST offers everything Markdown does, but not vice versa.
 
-reStructuredText is a file format for textual data used primarily in the Python programming language community for technical documentation. Both Markdown and RST are lightweight markup language. **The RST syntax is very similar to Markdown**, You can think RST as a super set of Markdown, RST has everything in Markdown, but Markdown doesn't.
-
-.. list-table:: **Why RST**
+.. list-table:: **Why use RST instead of Markdown**
     :widths: 10 10
     :header-rows: 1
 
-    * - Feature that RST has but Markdown NOT
-      - Why this feature useful
+    * - Features that RST has but Markdown does NOT
+      - Why this feature is useful
     * - Include other doc content
       - Help us break large doc into smaller piece, better maintainability.
     * - Cross reference anywhere in the entire project.
@@ -21,9 +19,9 @@ reStructuredText is a file format for textual data used primarily in the Python 
     * - Programmatically generate doc content from data.
       - Maintaining the data at two place in the code and in the doc is not good.
 
-**It is OK to write your doc in Markdown, but some design pattern will not be available**
+**Even though it is recommended to use RST for consistency and the feature benefits, but it is OK to use Markdown as well if that's what you prefer**
 
-For more information about writing docs in RST:
+For more information about writing docs in RST, check out:
 
 - RST Cheatsheet: https://github.com/ralsina/rst-cheatsheet/blob/master/rst-cheatsheet.rst
 - RST Quick Ref: http://docutils.sourceforge.net/docs/user/rst/quickref.html

--- a/docs/source/01-Document-Maintainer-Guide/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/index.rst
@@ -5,7 +5,9 @@ Document Developer Guide
     :depth: 1
     :local:
 
-This article aims to help:
+Akhlaq changes this
+
+This article aims to help Akhlaq:
 
 1. Non developer to understand how to contribute docs and do the doc review for other.
 2. Developer to know how to maintain the doc generation system set up, build doc, host the doc.

--- a/docs/source/01-Document-Maintainer-Guide/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/index.rst
@@ -1,0 +1,84 @@
+Document Developer Guide
+==============================================================================
+
+.. contents::
+    :depth: 1
+    :local:
+
+
+If You Are Doc Writer
+------------------------------------------------------------------------------
+
+**Step by Step: Make changes to the Doc**:
+
+1. Pull the latest code from `GitHub <https://github.com/18F/identity-analytics-etl>`_, create your own branch.
+2. Writing the doc in ``.rst`` or ``.md``, put the file in ``./identity-analytics-etl/docs/source``, for example ``./identity-analytics-etl/docs/source/FY2019-business-analytics-metrics.rst`` (File Style) or ``./identity-analytics-etl/docs/source/FY2019-business-analytics-metrics/index.rst`` (Folder Style).
+3. Issue a `PR <https://github.com/18F/identity-analytics-etl/pulls>`_, code review, deploy doc changes.
+
+If you are not familiar with Git / GitHub, read :ref:`use-github-client-to-update-docs`.
+
+.. note::
+
+    I highly recommend you write doc in RestructuredText instead of Markdown this is **WHY**: :ref:`md-vs-rst`.
+
+    A short answer is:
+
+    1. Markdown DOESN't HAVE CROSS FILE LINK.
+    2. 80% RST Syntax compatible with MD, the 20% includes **Header** and **Hyper Link**
+
+    Header:
+
+    .. code-block:: ReST
+
+        Markdown:
+
+        # Header1
+
+        ## Header2
+
+        ### Header3
+
+        RST:
+
+        Header1
+        ==========
+
+        Header2
+        ----------
+
+        Header3
+        ~~~~~~~~~~
+
+    Hyper Link::
+
+        Markdown:
+
+        [Google Homepage](www.google.com)
+
+        RST:
+
+        `Google Homepage <www.google.com>`_
+
+
+If you Are Doc Maintainer
+------------------------------------------------------------------------------
+
+1. If you are familiar with `Sphinx Doc <https://www.sphinx-doc.org/>`_, skip this section.
+2. If you are NOT, and want to know:
+    - :ref:`doc-maintenance-faq`
+    - How to include a document to the place where it is needed?
+    - How to build the doc site?
+    - How to deploy the doc site?
+    - :ref:`sphinx-doc-quick-explain`
+
+
+.. _why-sphinx-doc:
+
+Why Sphinx Doc
+------------------------------------------------------------------------------
+We use `Sphinx Doc <https://www.sphinx-doc.org/>`_ builder tool to automatically generate our documentation site.
+
+1. **Doc is part of the code, write once, deploy it to anywhere**. (The doc source file is sitting at ``identity-analytics-etl/docs/source/...``)
+2. **Automatically extract comment and doc string from code, generate API document** (auto generated API docs is sitting at ``identity-analytics-etl/docs/source/login_analytics``).
+3. No need to maintain same thing in TWO place.
+4. More powerful feature we really need such as, cross page reference, copy code to clipboard, auto table of content, literal including. Markdown and Github WIKI doesn't have it.

--- a/docs/source/01-Document-Maintainer-Guide/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/index.rst
@@ -11,9 +11,19 @@ If You Are Doc Writer
 
 **Step by Step: Make changes to the Doc**:
 
+**The Easy Way**:
+
+1. Go to https://github.com/18F/identity-analytics-etl/tree/master/docs/source, or the anywhere you want to create the doc file.
+2. Click button ``Create new file``.
+3. Write content in ``<filename>.rst`` (`RST Syntax <https://github.com/ralsina/rst-cheatsheet/blob/master/rst-cheatsheet.rst>`_, RECOMMENDED) or ``<filename>.md`` (Markdown Syntax)
+4. Commit the change. Create a :red:`new branch` for this commit, naming convention is ``<your-name>/<purpose-of-this-branch>``.
+5. Issue a `PR <https://github.com/18F/identity-analytics-etl/pulls>`_, ask other to do code review, deploy doc changes.
+
+**The Better Way (if you need to continually update the docs)**:
+
 1. Pull the latest code from `GitHub <https://github.com/18F/identity-analytics-etl>`_, create your own branch.
 2. Writing the doc in ``.rst`` or ``.md``, put the file in ``./identity-analytics-etl/docs/source``, for example ``./identity-analytics-etl/docs/source/FY2019-business-analytics-metrics.rst`` (File Style) or ``./identity-analytics-etl/docs/source/FY2019-business-analytics-metrics/index.rst`` (Folder Style).
-3. Issue a `PR <https://github.com/18F/identity-analytics-etl/pulls>`_, code review, deploy doc changes.
+3. Issue a `PR <https://github.com/18F/identity-analytics-etl/pulls>`_, ask other to do code review, deploy doc changes.
 
 If you are not familiar with Git / GitHub, read :ref:`use-github-client-to-update-docs`.
 

--- a/docs/source/01-Document-Maintainer-Guide/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/index.rst
@@ -5,6 +5,11 @@ Document Developer Guide
     :depth: 1
     :local:
 
+This article aims to help:
+
+1. Non developer to understand how to contribute docs and do the doc review for other.
+2. Developer to know how to maintain the doc generation system set up, build doc, host the doc.
+
 
 If You Are Doc Writer
 ------------------------------------------------------------------------------
@@ -80,6 +85,19 @@ If you Are Doc Maintainer
     - How to build the doc site?
     - How to deploy the doc site?
     - :ref:`sphinx-doc-quick-explain`
+
+
+If you Are Doing Doc Review
+------------------------------------------------------------------------------
+
+1. Go to the `Pull Request <https://github.com/18F/identity-analytics-etl/pull>`_, find the specific PR, for example, `This One <https://github.com/18F/identity-analytics-etl/pull/155>`_.
+2. Click `Files Changed <https://github.com/18F/identity-analytics-etl/pull/155/files>`_, to see the file changes.
+3. Click `View File <https://github.com/18F/identity-analytics-etl/blob/607c3c064413a7c1a23c52d071751326b2111ab5/docs/source/01-Document-Maintainer-Guide/index.rst>`_ on doc source file (usually ``.rst`` or ``.md``) to preview the doc.
+4. Click on the line (the ``+`` icon), leave your comment and suggestion.
+5. Finally, Click ``Review changes`` button to take an action in one of ``Comment``, ``Approve`` or ``Request changes``.
+
+    .. image:: https://img.shields.io/badge/-Review_changes-brightgreen.svg
+
 
 
 .. _why-sphinx-doc:

--- a/docs/source/01-Document-Maintainer-Guide/index.rst
+++ b/docs/source/01-Document-Maintainer-Guide/index.rst
@@ -5,12 +5,10 @@ Document Developer Guide
     :depth: 1
     :local:
 
-Akhlaq changes this
+This articled is targeted for:
 
-This article aims to help Akhlaq:
-
-1. Non developer to understand how to contribute docs and do the doc review for other.
-2. Developer to know how to maintain the doc generation system set up, build doc, host the doc.
+1. Non developer to help them understand how to contribute to docs and perform reviews for others.
+2. Developers to understand how to maintain the doc generation system set up, build doc, host the doc.
 
 
 If You Are Doc Writer
@@ -26,7 +24,7 @@ If You Are Doc Writer
 4. Commit the change. Create a :red:`new branch` for this commit, naming convention is ``<your-name>/<purpose-of-this-branch>``.
 5. Issue a `PR <https://github.com/18F/identity-analytics-etl/pulls>`_, ask other to do code review, deploy doc changes.
 
-**The Better Way (if you need to continually update the docs)**:
+**The Preferred Way (if you need to continually update the docs)**:
 
 1. Pull the latest code from `GitHub <https://github.com/18F/identity-analytics-etl>`_, create your own branch.
 2. Writing the doc in ``.rst`` or ``.md``, put the file in ``./identity-analytics-etl/docs/source``, for example ``./identity-analytics-etl/docs/source/FY2019-business-analytics-metrics.rst`` (File Style) or ``./identity-analytics-etl/docs/source/FY2019-business-analytics-metrics/index.rst`` (Folder Style).
@@ -40,7 +38,7 @@ If you are not familiar with Git / GitHub, read :ref:`use-github-client-to-updat
 
     A short answer is:
 
-    1. Markdown DOESN't HAVE CROSS FILE LINK.
+    1. Markdown does not offer cross file link.
     2. 80% RST Syntax compatible with MD, the 20% includes **Header** and **Hyper Link**
 
     Header:
@@ -80,8 +78,8 @@ If you are not familiar with Git / GitHub, read :ref:`use-github-client-to-updat
 If you Are Doc Maintainer
 ------------------------------------------------------------------------------
 
-1. If you are familiar with `Sphinx Doc <https://www.sphinx-doc.org/>`_, skip this section.
-2. If you are NOT, and want to know:
+If you are familiar with `Sphinx Doc <https://www.sphinx-doc.org/>`_, skip this section. If you are NOT, read on.
+
     - :ref:`doc-maintenance-faq`
     - How to include a document to the place where it is needed?
     - How to build the doc site?
@@ -111,4 +109,4 @@ We use `Sphinx Doc <https://www.sphinx-doc.org/>`_ builder tool to automatically
 1. **Doc is part of the code, write once, deploy it to anywhere**. (The doc source file is sitting at ``identity-analytics-etl/docs/source/...``)
 2. **Automatically extract comment and doc string from code, generate API document** (auto generated API docs is sitting at ``identity-analytics-etl/docs/source/login_analytics``).
 3. No need to maintain same thing in TWO place.
-4. More powerful feature we really need such as, cross page reference, copy code to clipboard, auto table of content, literal including. Markdown and Github WIKI doesn't have it.
+4. Powerful feature set such as cross page reference, copy code to clipboard, auto table of content, literal including. Markdown and Github WIKI do not offer these.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,8 +53,10 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-# source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
+source_parsers = {
+   '.md': 'recommonmark.parser.CommonMarkParser',
+}
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,6 +4,11 @@ Release v\ |release| (:ref:`What's new? <release_history>`).
 
 .. include:: ../../README.rst
 
+Table of Content
+------------------------------------------------------------------------------
+
+.. articles::
+
 
 API Document
 ------------------------------------------------------------------------------

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,6 +1,7 @@
 # dependencies to build documentation
 docutils
 sphinx==1.8.1
+recommonmark
 
 # sphinx doc plugins
 sphinx-jinja        # allow jinja2 template

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,7 +1,7 @@
 # dependencies to build documentation
 docutils
 sphinx==1.8.1
-recommonmark
+recommonmark                # Markdown Parser
 
 # sphinx doc plugins
 sphinx-jinja        # allow jinja2 template


### PR DESCRIPTION
**Why**:

1. Add guide for `How to contribute doc` as a Writer.
2. Add guide for `How to maintain the doc site` as a Developer.

So:

- any non-developer can contribute docs and allow the maintainer to merge it to the doc site.
- any developer can easily take over the doc site management work.

**How to review**:

**Highlight**:

You can preview the changes at: https://s3-us-west-2.amazonaws.com/login-gov-doc/login_analytics/01-Document-Maintainer-Guide/index.html

This is the [guide](https://github.com/18F/identity-analytics-etl/blob/0f9a4611ba411bdda3350b05cdf48186d3218060/docs/source/01-Document-Maintainer-Guide/index.rst) for:

- If You Are Doc Writer
- If you Are Doc Maintainer
- If you Are Doing Doc Review