### PR TITLE
add auto sql doc extension

### DIFF
--- a/docs/source/02-Analytics-Query/lookup.rst
+++ b/docs/source/02-Analytics-Query/lookup.rst
@@ -4,16 +4,7 @@ Query Lookup
 ==============================================================================
 
 .. contents::
+    :depth: 1
     :local:
 
-
-.. todo::
-
-    Create an extension to automatically organize all .sql docs
-
-
-How-many-total-user-in-the-DB
-------------------------------------------------------------------------------
-
-.. literalinclude:: ./User-Count/How-many-total-user-in-the-DB.sql
-    :language: sql
+.. autosqldoc::

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ extensions = [
     'sphinxcontrib.jinja',
     'sphinx_copybutton',
     'docfly.directives',
+    'login_analytics.docs.directives',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/login_analytics/docs/auto_sql_doc.py
+++ b/login_analytics/docs/auto_sql_doc.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+
+"""
+This is an sphinx extension
+
+This is how we organize sql file in file system::
+
+    Analytics-Query
+    |-- <Sql-Group-Name1>
+        |-- <filename1>.sql
+        |-- <filename2>.sql
+        |-- ... (may have nested folder)
+
+This extension will create a header for each sql group, and create a sub header
+for each ``.sql`` file. Derives RST content like::
+
+    SQL GROUP NAME 1
+    ----------------
+
+    table of content: ...
+
+    filename1
+    ~~~~~~~~~
+    description ...
+
+    .. code-block:: sql
+
+        sql statement ...
+
+    ...
+"""
+
+from __future__ import unicode_literals
+import re
+import sphinx.util
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.statemachine import StringList
+from pathlib_mate import PathCls as Path
+from rstobj.markup import Header
+from rstobj.directives import TableOfContent, CodeBlockSQL
+
+
+COMMENT_PATTERN = re.compile("/\*[\s\S]*\*/")
+root = Path("/Users/sanhehu/Documents/GitHub/identity-analytics-etl/docs/source/02-Analytics-Query")
+
+
+def extract_comment_and_sql(content):
+    """
+    Separate comment and SQL statement from a sql file.
+    Comment block is the text in ``/* <comment-block> */``
+
+    :param content: str
+    :return: comment, str; sql_state, str;
+    """
+    comment_blocks = re.findall(COMMENT_PATTERN, content)
+    comment = "\n\n".join([
+        block[2:-2].strip() for block in comment_blocks
+    ]).strip()
+    for cmt in comment_blocks:
+        content = content.replace(cmt, "\n\n")
+    sql_stat = content.strip()
+    return comment, sql_stat
+
+
+def generate_rst(root_dir):
+    """
+    Generate RST content, including all ``.sql`` content, and organize them
+    in a proper way.
+
+    :param root_dir: ``pathlib.Path``, The root directory.
+        usually it is the ``Analytics-Query`` folder.
+    :return: rst text.
+    """
+
+    def filters(p):
+        if (p.ext == ".sql") and (p.parent.basename != "draft"):
+            return True
+        else:
+            return False
+
+    group_set = set()  # sql group duplicate filter
+    rst_lines = list()
+    for p in Path.sort_by_abspath(root_dir.select_file(filters)):
+        rel_path = p.relative_to(root)
+        relative_parts = rel_path.parts
+
+        # create a header2 for sql group, and auto index items
+        group_title = relative_parts[0]
+        if group_title not in group_set:
+            header = Header(title=group_title, header_level=2, auto_label=True)
+            rst_lines.append(header.render())
+            toc = TableOfContent(local=True)
+            rst_lines.append(toc.render())
+            group_set.add(group_title)
+
+        # file name to be the title
+        header_title = p.fname
+        header = Header(title=header_title, header_level=3, auto_label=True)
+        rst_lines.append(header.render())
+        comment, sql_stat = extract_comment_and_sql(content=p.read_text("utf-8"))
+        # comment to be the body text
+        rst_lines.append(comment)
+
+        # sql_stat to be the code snippet
+        code_block = CodeBlockSQL.from_string(sql_stat)
+        rst_lines.append(code_block.render())
+
+    rst = "\n\n".join(rst_lines)
+    return rst
+
+
+class AutoSqlDoc(Directive):
+    """
+    Implement ``autosqldoc`` directive::
+
+        .. autosqldoc::
+    """
+    has_content = False
+
+    def run(self):
+        node = nodes.Element()
+        node.document = self.state.document
+        current_file = self.state.document.current_source
+        output_rst = generate_rst(Path(current_file).parent)
+        view_list = StringList(output_rst.splitlines(), source='')
+        sphinx.util.nested_parse_with_titles(self.state, view_list, node)
+        return node.children

--- a/login_analytics/docs/directives.py
+++ b/login_analytics/docs/directives.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from .auto_sql_doc import AutoSqlDoc
+
+
+def setup(app):
+    app.add_directive("autosqldoc", AutoSqlDoc)

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -7,6 +7,7 @@ recommonmark                # Markdown Parser
 sphinx-jinja        # allow jinja2 template
 sphinx-copybutton   # add copy to clipboard button for code block
 docfly==0.0.17      # auto API manual, auto Table of Content
+rstobj==0.0.5       # generate RestructuredText
 
 # Other
 


### PR DESCRIPTION
**Why**:

This is how we organize ``sql`` file in file system, [example here](https://github.com/18F/identity-analytics-etl/tree/sanhe/auto-analytics-query-doc-extension/docs/source/02-Analytics-Query):

    Analytics-Query
    |-- <Sql-Group-Name1>
        |-- <filename1>.sql
        |-- <filename2>.sql
        |-- ... (may have nested folder)
    |--- <Sql-Group-Name2>
        |-- ...

We need an extension automatically organize them in a proper way and generate human readable doc.

Basically, generate doc content like:

    SQL GROUP NAME 1
    ----------------

    table of content: ...

    filename1
    ~~~~~~~~~
    description ...

    .. code-block:: sql

        sql statement ...

    ...

This is a live example: https://s3-us-west-2.amazonaws.com/login-gov-doc/login_analytics/02-Analytics-Query/lookup.html

Then user is able to search them by keyword or quickly locate them in table of content.

**How**:

Implement an ``.. autosqldoc::`` directive, and put it in ``Analytics-Query`` root directory [Example here](https://raw.githubusercontent.com/18F/identity-analytics-etl/sanhe/auto-analytics-query-doc-extension/docs/source/02-Analytics-Query/lookup.rst)