### PR TITLE
add sql development in cmd guide, and integrate it to the site

### DIFF
--- a/docs/source/02-Analytics-Query/articles/How-To-Run-Query-on-IDP-DB.rst
+++ b/docs/source/02-Analytics-Query/articles/How-To-Run-Query-on-IDP-DB.rst
@@ -1,7 +1,9 @@
-.. _how-to-run-query-on-idp-db-in-ruby-console:
+.. _how-to-run-query-on-idp-db:
 
-How To Run a Custom Query on IDP DB in Ruby Console
+How To Run a Custom Query on IDP DB
 ==============================================================================
+
+**IDB DB** is the production database serving login.gov website. It has less information than Redshift, but more accurate.
 
 .. contents::
     :local:
@@ -16,10 +18,12 @@ How To Run a Custom Query on IDP DB in Ruby Console
 - **Setup your AWS CLI**, follow this guide: https://aws.amazon.com/cli/. Configure your ``~/.aws/credentials`` and ``~/.aws/config``, put the ``identity-prod`` AWS Account API credential in it.
 
 
-2. SSH to prod instance
+.. _ssh-to-prod-server:
+
+2. SSH to prod server
 ------------------------------------------------------------------------------
 
-1. Establish SSH to current IDP prod server (ec2 instance):
+Establish SSH to current IDP prod server (ec2 instance):
 
 first:
 
@@ -90,12 +94,14 @@ Then log in to psql:
     cd /srv/idp/current
     sudo -uwebsrv RAILS_ENV=production ALLOW_CONSOLE_DB_WRITE_ACCESS=true bundle exec rails dbconsole
 
-It will ask you for password. There are only two db user account, and `rails dbconsole` will lead you to the app account, which means you have the **Write** access. **Please be very careful about that!**:
+`rails dbconsole` option will lead you to the app account, which means you have the **Write** access. **Please be very careful about that!**
+
+There are only two db user accounts:
 
 1. login.gov app
 2. Read only account
 
-Run this command on your local machine to get your db password:
+Run this command (with ``identity-prod`` AWS Account IAM credential) on your local machine to get your db password:
 
 .. code-block:: bash
 

--- a/docs/source/02-Analytics-Query/articles/README.rst
+++ b/docs/source/02-Analytics-Query/articles/README.rst
@@ -1,0 +1,1 @@
+Analytics Query Relative Articles

--- a/docs/source/02-Analytics-Query/articles/SQL-Development-in-Command-Line-Guide.rst
+++ b/docs/source/02-Analytics-Query/articles/SQL-Development-in-Command-Line-Guide.rst
@@ -1,0 +1,127 @@
+.. meta::
+    :author: Sanhe Hu
+
+.. _sql-development-in-command-line-guide:
+
+SQL Development in Command Line Guide
+==============================================================================
+
+.. note::
+
+    DON'T RUN EXPENSIVE QUERY ON PROD. Use:
+
+    - limit returns: ``LIMIT 5``
+    - use aggregate function: ``SELECT COUNT(*) FROM ... GROUP BY *``
+
+Since we can't grant everyone sql client access, the sql developer has to SSH to secure server, then execute query via ``psql`` in command line interface.
+
+Unlike using a sql client software, there is no **sql editor**, **tabulate data viewer**, **result export service** in psql shell.
+
+Here's some tricks you can use to make your life easier.
+
+.. contents::
+    :local:
+
+
+Edit Multi-Line Query
+------------------------------------------------------------------------------
+
+You should edit long query in any text editor, then copy and paste it in psql shell. Be careful about:
+
+1. end query with ``;``
+2. use 2/4/8 space instead of TAB for indent.
+
+For example:
+
+.. code-block:: SQL
+
+    SELECT
+        E.user_count as user_count,
+        service_providers.friendly_name as sp_name,
+        E.sp_uri as sp_uri,
+    FROM
+    (
+        SELECT
+            COUNT(identities.user_id) AS user_count,
+            identities.service_provider AS sp_uri
+        FROM identities
+        GROUP BY identities.service_provider
+    ) as E
+    JOIN service_providers
+    ON E.sp_uri = service_providers.issuer;
+
+
+View Big Ascii Table
+------------------------------------------------------------------------------
+
+Psql returns the result in ascii table by default. But sometimes the width of the table is greater than the command line window. In this case you need to **toggle off line wrapping** in your terminal software.
+
+For Mac, we have:
+
+**Disable** line wrapping::
+
+    tput rmam
+
+**Enable** line wrapping::
+
+    tput smam
+
+Reference:
+
+- https://stackoverflow.com/questions/28954083/how-to-turn-off-word-wrap-in-iterm2
+
+
+Export Result to TSV File
+------------------------------------------------------------------------------
+
+``psql`` ASCII Table is very human-readable, but not friendly to machine. Writing the result to a csv file for further analysis is a better option. I recommend using TSV (Tab separate) over CSV in general. Because TSV is better for:
+
+- ``,`` character escaping.
+- Can be directly copy and paste to Excel / Google Sheet.
+
+``psql`` has a built-in ``copy`` command https://www.postgresql.org/docs/current/sql-copy.html for this. This is an example of exporting data in TSV format::
+
+    \copy (SELECT * FROM service_providers) to '/tmp/service_providers.csv' with (FORMAT CSV, HEADER, DELIMITER E'\t');
+
+A problem is **\copy command DOES NOT support multi-line query**!
+
+My solution is to **create a temp view** which can be declared over multiple lines, then select from it in the ``\copy`` command, which fits comfortably on one line.
+
+Example (Replace the ``SELECT * FROM service_providers`` with custom query):
+
+.. code-block:: sql
+
+    CREATE TEMP VIEW v_temp AS (
+        SELECT *
+        FROM service_providers
+    );
+    \copy (SELECT * FROM v_temp) to '/tmp/service_providers.csv' with (FORMAT CSV, HEADER, DELIMITER E'\t');
+    DROP VIEW v_temp;
+
+Then you can find the result in TSV format at ``/tmp/service_providers.csv``.
+
+Reference:
+
+- https://stackoverflow.com/questions/42404579/use-psqls-copy-for-a-multi-line-query
+
+
+Copy TSV Result to your Local Machine
+------------------------------------------------------------------------------
+
+By default, ipd server doesn't allows to transfer data out from it with the ``ssh`` command. But the ``identity-devops`` repo has a **command line tool** ``scp-instance`` can securely do that.
+
+First, follow this :ref:`Guide <ssh-to-prod-server>`, **ssh to idp server**::
+
+    ./bin/ssh-instance --newest asg-prod-idp
+
+You should able to see the instance ID in the dialogue::
+
+    I, [2018-12-10T14:06:02.132128 #55154]  INFO -- ssh-instance: SSH to "asg-prod-idp" (i-02d618ed7f9db11a2)
+
+Then copy TSV file to your local machine::
+
+    ./bin/scp-instance <instance-id>:<file-path-on-server> <destination-path>
+
+In this example, it is::
+
+    ./bin/scp-instance i-02d618ed7f9db11a2:/tmp/service_providers.csv ~/service_providers.csv

--- a/docs/source/02-Analytics-Query/index.rst
+++ b/docs/source/02-Analytics-Query/index.rst
@@ -3,6 +3,10 @@
 Analytics Query
 ==============================================================================
 
+.. contents::
+    :depth: 1
+    :local:
+
 We use sphinx-doc automatically generating analytics queries. The doc builder will automatically scan ``.sql`` file in ``Analytics-Query`` directory, extract doc and sql statement, then organize them in a human readable and searchable way.
 
 Please make sure there is only one sql for each file. And put all corresponding document in :ref:`RST syntax <md-vs-rst>` between ``/* document ... */``. And you can also put the description for entire user group in the ``README.rst`` file.
@@ -37,3 +41,12 @@ If you CAN NOT find the query you need, here's the way to request:
 3. Create a new ``Pull Request``, and fill the code commit message.
 4. Then the developer will get notified.
 
+
+For IDP DB Query Developer
+------------------------------------------------------------------------------
+
+.. toctree::
+    :maxdepth: 1
+
+    ./articles/How-To-Run-Query-on-IDP-DB.rst
+    ./articles/SQL-Development-in-Command-Line-Guide.rst


### PR DESCRIPTION
**Why**:

Develop SQL in the command line is painful. Some tricks can be helpful. Content includes:

- Edit Multi-Line Query
- View Big Ascii Table
- Export Result to TSV File
- Copy TSV Result to your Local Machine

**Things done in this PR**:

1. Add a ``SQL-Development-in-Command-Line-Guide.rst``.
2. Integrate ``How-To-Run-Query-on-IDP-DB.rst`` and ``SQL-Development-in-Command-Line-Guide.rst`` to doc site, in ``Analytics Query`` page.