### PR TITLE
read host value from either hostname or host field

### DIFF
--- a/legacy_code/src/event_parser.py
+++ b/legacy_code/src/event_parser.py
@@ -58,7 +58,7 @@ class EventParser(BaseEventParser):
             data.get('properties').get('user_agent'),
             data.get('properties').get('user_id'),
             data.get('properties').get('user_ip'),
-            data.get('properties').get('host'),
+            self.get_host(data.get('properties', {})),
             data.get('visit_id'),
             data.get('visitor_id'),
             re.sub(r"\.\d+Z$", '', data.get('time').replace('T', ' ')),

--- a/legacy_code/src/log_parser.py
+++ b/legacy_code/src/log_parser.py
@@ -97,6 +97,20 @@ class Parser(object):
             df[k] = df[k].astype(v)
         return df
 
+    @staticmethod
+    def get_host(data):
+        """
+        Get host value from dictionary data.
+
+        Devops changed the `host` key in the rails logs to `hostname`
+        due to a conflict with elasticsearch
+        """
+        if data.get('hostname') is not None:
+            return data.get('hostname')
+        else:
+            return data.get('host')
+
+
 
 class BaseEventParser(Parser):
     JSON_PREFIX_PATTERN = '"name":'

--- a/legacy_code/src/pageview_parser.py
+++ b/legacy_code/src/pageview_parser.py
@@ -50,7 +50,7 @@ class PageViewParser(Parser):
                     data['path'],
                     data['ip'],
                     data['timestamp'],
-                    data['host'],
+                    self.get_host(data),
                     str(data['duration'])
                 ]).encode('utf-8')
             ).hexdigest()
@@ -83,7 +83,7 @@ class PageViewParser(Parser):
             data.get('user_id'),
             data.get('user_agent'),
             data.get('ip'),
-            data.get('host'),
+            self.get_host(data),
             uuid,
             re.sub(r" \+\d+$", '', data.get('timestamp'))
         ]


### PR DESCRIPTION
**Description**:

Adapt the change that: Devops changed the `host` key in the rails logs to `hostname` due to a conflict with elasticsearch.

**How**:

Add a ``get_host(data)`` method, try reading data from ``hostname`` first, if failed, then try with ``host``. It will help us smoothly migrate to new pattern.


