### PR TITLE
Add ETL pipeline maintainer guide, and fix the get_all_csv timeout issue

### DIFF
--- a/docs/source/03-ETL-Pipeline-Maintainer-Guide/ETL-Pipeline-Failure-from-2019-02-09-to-2019-03-04-Summary.rst
+++ b/docs/source/03-ETL-Pipeline-Maintainer-Guide/ETL-Pipeline-Failure-from-2019-02-09-to-2019-03-04-Summary.rst
@@ -1,0 +1,30 @@
+ETL Pipeline Failure from 2019-02-09 to 2019-03-04 Summary
+==============================================================================
+
+
+Description
+------------------------------------------------------------------------------
+Redshift stopped receiving any data from 2019-02-09.
+
+The Logstash data are correctly parsed and sitting in Hot Bucket, but data are not correctly loaded to Redshift.
+
+
+Reason Investigation
+------------------------------------------------------------------------------
+
+We have a table ``uploaded_files`` in redshift working as duplicate filter. Lambda makes S3 API call to get list of CSV file, and filter out those already done from ``uploaded_files`` table. But around 2019-02-09, too many files are uploaded to Hot Bucket, which causes the S3 API call for getting list of CSV files to time out.
+
+
+Solution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since files are immediately deleted from Hot bucket after the data has been loaded to Redshift. We actually use the Hot Bucket as a fake ``Task Queue``. But it is still possible to having large number of files in the Hot Bucket. We should limit number of files to retrieve from S3 in API Call.
+1000 is a good number.
+
+
+Current Status
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The patch code is deployed, now we overstocked **450,000 files**. I can visually see that number of rows data are growing after I fixed it. The rate is like 250 files per 5 min, it takes **450,000 / 250 x 5 / 60 = 150 Hour** to repopulate everything.
+
+Our normal workload only takes 1 minute to run, invoke every 5 minutes. Because we want to process overstock asap, I changed the cron job from 5 min to 1 min, and will change it back once all data are re-uploaded. Approximately it takes **150 / 5 = 30 Hour**

--- a/docs/source/03-ETL-Pipeline-Maintainer-Guide/etl-pipeline-debug-guide-v1.rst
+++ b/docs/source/03-ETL-Pipeline-Maintainer-Guide/etl-pipeline-debug-guide-v1.rst
@@ -1,0 +1,126 @@
+ETL Pipeline Debug Guide V1
+==============================================================================
+
+
+Check Status of the Pipeline
+------------------------------------------------------------------------------
+
+
+Do we have data in Redshift?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Currently, we manually run this sql scripts every week. It gives me counts of rows we have every days. You can visually check if there is missing data. If you observed significant drop in any date, it means that **ETL Pipeline is having problems.**
+
+.. code-block:: SQL
+
+    \set start_time '''2018-09-01'''
+
+    SELECT
+        EVENTS.day,
+        EVENTS.events_count as events_count,
+        EVENTS_EMAIL.events_email_count as events_email_count,
+        EVENTS_PHONE.events_phone_count as events_phone_count,
+        EVENTS_DEVICES.events_devices_count as events_devices_count,
+        PAGEVIEWS.pageviews_count as pageviews_count
+    FROM
+    (
+        SELECT
+            date_trunc('day', E.time) as day,
+            COUNT(*) as events_count
+        FROM events as E
+        WHERE time >= :start_time
+        GROUP BY day
+    ) EVENTS
+    LEFT JOIN
+    (
+        SELECT
+            date_trunc('day', E_EMAIL.time) as day,
+            COUNT(*) as events_email_count
+        FROM events_email as E_EMAIL
+        WHERE time >= :start_time
+        GROUP BY day
+    ) EVENTS_EMAIL
+    ON EVENTS.day = EVENTS_EMAIL.day
+    LEFT JOIN
+    (
+        SELECT
+            date_trunc('day', E_PHONE.time) as day,
+            COUNT(*) as events_phone_count
+        FROM events_phone as E_PHONE
+        WHERE time >= :start_time
+        GROUP BY day
+    ) EVENTS_PHONE
+    ON EVENTS.day = EVENTS_PHONE.day
+    LEFT JOIN
+    (
+        SELECT
+            date_trunc('day', E_DEVICES.time) as day,
+            COUNT(*) as events_devices_count
+        FROM events_devices as E_DEVICES
+        WHERE time >= :start_time
+        GROUP BY day
+    ) EVENTS_DEVICES
+    ON EVENTS.day = EVENTS_DEVICES.day
+    LEFT JOIN
+    (
+        SELECT
+            date_trunc('day', PV.timestamp) as day,
+            COUNT(*) as pageviews_count
+        FROM pageviews as PV
+        WHERE timestamp >= :start_time
+        GROUP BY day
+    ) PAGEVIEWS
+    ON EVENTS.day = PAGEVIEWS.day
+    ORDER BY EVENTS.day DESC;
+
+Example Output (Updated on 2018-10-26)::
+
+             day         | events_count | events_email_count | events_phone_count | events_devices_count | pageviews_count
+    ---------------------+--------------+--------------------+--------------------+----------------------+-----------------
+     2018-10-15 00:00:00 |      xxxxxxx |              xxxxx |             xxxxxx |              xxxxxxx |         xxxxxxx
+     2018-10-14 00:00:00 |      xxxxxxx |              xxxxx |             xxxxxx |              xxxxxxx |         xxxxxxx
+     2018-10-13 00:00:00 |      xxxxxxx |              xxxxx |             xxxxxx |              xxxxxxx |         xxxxxxx
+     2018-10-12 00:00:00 |      xxxxxxx |              xxxxx |             xxxxxx |              xxxxxxx |         xxxxxxx
+     2018-10-11 00:00:00 |      xxxxxxx |              xxxxx |             xxxxxx |              xxxxxxx |         xxxxxxx
+
+
+Does lambda have problems with invoke count, time duration, errors counts?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Go AWS Console -> ``18-identity-analytics`` account -> lambda -> functions -> ``analytics-etl-prod`` (parser) ``analytics-etl-hot-prod`` (loader), take a look at Monitor Menu
+
+
+Pin Point the Problem
+------------------------------------------------------------------------------
+
+
+Check Lambda Function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. AWS Console -> ``18-identity-analytics`` account -> lambda -> functions -> ``analytics-etl-prod`` (parser) ``analytics-etl-hot-prod`` (loader)
+2. Monitor Tab select missing data time range, check duration, and errors rate. avg duration for ``analytics-etl-prod`` is 10 ~ 12 seconds. avg for ``analytics-etl-hot-prod`` is around 5 minutes.
+3. Select time range on dashboard, click the 3-dot button at top right on the plot -> View logs -> AWS/Lambda - /aws/lambda/<function-name>
+4. Search ``REPORT``, it is the end of log in each invoke, you should search for ``TIMEOUT`` or ``OUT OF MEMORY`` problem.
+5. Search ``ERROR``, find runtime exeception.
+
+
+Check S3 Bucket
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. check ``s3://login-gov-prod-xxxxxxxxxx-us-west-2-analytics-hot/elk``, parsed files should be put here if ``analytics-etl-prod`` function works. If it is empty, it doesn't mean the ``analytics-etl-prod`` failed. Because ``analytics-etl-hot-prod`` will delete the file once parsed file is uploaded to Redshift. **If you can't observe any files in this bucket for long time, it means the parser failed**.
+
+2. check ``s3://login-gov-prod-log/elk`` (in ``18-identity`` AWS account), randomly download some files, check if it has valid data.
+
+
+Debug Parser
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Go Lambda Function ``analytics-etl-prod``, click Actions Menu, Export function, download source code.
+
+execute the file you download with ``Uploader.etl`` method in ``src/uploader.py``.
+
+
+Debug Loader
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Execute lambda handler ``function_2.lambda_handler`` locally.

--- a/docs/source/03-ETL-Pipeline-Maintainer-Guide/index.rst
+++ b/docs/source/03-ETL-Pipeline-Maintainer-Guide/index.rst
@@ -1,0 +1,8 @@
+ETL Pipeline Maintainer Guide
+==============================================================================
+
+.. toctree::
+    :maxdepth: 1
+
+    etl-pipeline-debug-guide-v1.rst
+    ETL-Pipeline-Failure-from-2019-02-09-to-2019-03-04-Summary.rst

--- a/legacy_code/src/s3.py
+++ b/legacy_code/src/s3.py
@@ -60,7 +60,7 @@ class S3:
 
     def get_all_csv(self):
         get_last_modified = lambda x: int(x.last_modified.strftime('%s'))
-        files = [f for f in self.hot_bucket.objects.all() if self.csv_check(f.key)]
+        files = [f for f in self.hot_bucket.objects.all().limit(1000) if self.csv_check(f.key)]
         sorted_files = sorted(files, key=get_last_modified, reverse=False)
         return [f.key for f in sorted_files]
 


### PR DESCRIPTION
---
labels: task
---
## Summary

(the #198 is closed due to Git History disordered issue, will use this PR to solve the same issue)

ETL Pipeline failed on 2019-02-09. I think a Debug Guide, and a Summary for this event could save up lots of time on fixing ETL pipeline in the future.

Please note if fully resolves the issue per the acceptance criteria: Y

*Describe the pull request here, including any supplemental information needed to understand it.*

1. add a debug guide
2. add a summary

## This pull request is ready to merge when...

- [x] Documentation / readme.md updated (manual)
- [x] Feature branch is starts with the issue number (we don't have a user story for this)
- [ ] This code has been reviewed by someone other than the original author
